### PR TITLE
docs: add local bio connector installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ DeepSeek 原生 Anthropic 端点  /  通义千问等 OpenAI 兼容端点
 - 本项目仅供**个人学习与研究**用途，**使用者自负风险**。
 - 推理请求经本地代理直连你自己付费的第三方模型，**不经过 Anthropic 服务端**做推理，用的是本地自造的虚拟登录，**零真实 Anthropic 凭证**。
 - Science 在**启动阶段**仍会尝试访问其硬编码的 profile / account 接口（`api.anthropic.com` / `claude.ai`）；代理对这些请求即时短路（返回「未登录」），Science 以未登录态正常启动、不影响第三方推理。因此本项目**不宣称**「完全零 Anthropic 接触」这类绝对说法。
-- 虚拟登录下，**Anthropic 托管的远程 MCP 服务**（如 pubmed / clinical-trials / chembl / biorxiv，位于 `*.mcp.claude.com`）不可用：它们需真实 Anthropic 授权，代理已将其短路，Science 会自动跳过（启动日志有 `load failed (skipped)` 属正常）。**本地内置的 bio-tools MCP 仍正常可用。**
+- 虚拟登录下，**Anthropic 托管的远程 MCP 服务**（如 pubmed / clinical-trials / chembl / biorxiv，位于 `*.mcp.claude.com`）不可用：它们需真实 Anthropic 授权，代理已将其短路，Science 会自动跳过（启动日志有 `load failed (skipped)` 属正常）。**本地内置的 bio-tools MCP 仍正常可用**；需要这四个 HCLS 连接器时，可运行 [`scripts/install-local-bio-connectors.sh`](./scripts/install-local-bio-connectors.sh) 把它们补成本地 stdio 连接器，细节见 [`docs/local-bio-connectors.md`](./docs/local-bio-connectors.md)。
 - 对 Science 登录令牌加密格式的逆向、以及「越过登录」的实现，可能触及相关服务条款与版权法规（如美国 DMCA §1201 反规避条款）。是否适用、有无豁免需专业法律判断。
 - 本项目与 Anthropic **无任何从属、合作或背书关系**；不偷取算力（推理走你自付第三方）、不泄露用户密钥、不含恶意代码。
 - 软件按「现状」提供，**不提供任何形式的担保**。

--- a/docs/local-bio-connectors.md
+++ b/docs/local-bio-connectors.md
@@ -1,0 +1,58 @@
+# 本地 bio connectors
+
+Claude Science 的 Connectors Directory 里有一组 HCLS（health and life sciences，健康与生命科学）远程连接器，例如 PubMed、Clinical Trials、ChEMBL、bioRxiv。它们在官方环境里由 Anthropic 托管，虚拟登录沙箱没有真实 claude.ai 组织会话，所以这些 hosted connectors（官方托管连接器）会显示 `Failed`。
+
+这不代表所有 MCP（Model Context Protocol，模型工具协议）都不可用。Claude Science runtime（运行时）里同时带有本地 `bio-tools` stdio（标准输入输出，本机进程通信）实现。CSSwitch 可以把这四个远程连接器补成显式的本地连接器：
+
+- `pubmed-local`
+- `clinical-trials-local`
+- `chembl-local`
+- `biorxiv-local`
+
+## 一键安装
+
+先用 CSSwitch 启动 Claude Science 沙箱，然后运行：
+
+```bash
+scripts/install-local-bio-connectors.sh
+```
+
+可选参数：
+
+```bash
+scripts/install-local-bio-connectors.sh \
+  --data-dir "$HOME/.csswitch/sandbox/home/.claude-science" \
+  --port 8990 \
+  --agent OPERON
+```
+
+脚本会幂等执行（重复运行不会重复创建）：
+
+1. 通过本地 single-use URL（一次性登录链接）换取 daemon（守护进程）API cookie。
+2. 调用 `/api/mcp-servers/local` 注册四个 local-stdio 连接器。
+3. 把本地连接器挂到目标 agent（代理，默认 `OPERON`）。
+4. 从该 agent 卸载对应的 `bundled:*` 官方远端连接器，避免工具路由碰到失败的 hosted connector。
+
+脚本只会写 CSSwitch 沙箱 data-dir，默认是：
+
+```text
+~/.csswitch/sandbox/home/.claude-science
+```
+
+它拒绝真实目录：
+
+```text
+~/.claude-science
+```
+
+## 预期 UI
+
+运行后，Directory（官方连接器目录）里的 PubMed、Clinical Trials、ChEMBL、bioRxiv 仍可能显示 `Failed`。这是官方远端目录项的状态，不是本地替身的状态。
+
+真正给 `OPERON` 使用的是 `*-local` 连接器。脚本末尾会验证这些本地连接器已经 connected（已连接）并且工具数量非零。
+
+## 性能与限制
+
+本地 stdio 连接器会在本机启动 Python MCP 进程。空闲压力较低，实际负载主要来自搜索、JSON/XML 解析和全文抓取。大批量全文下载或多个会话并发调研时，会增加 CPU、内存和网络压力。
+
+这些本地连接器复用 Claude Science runtime 自带的工具代码和 schema（工具接口定义）。脚本只改变连接器注册与 agent 挂载，不改工具函数本身。

--- a/scripts/install-local-bio-connectors.sh
+++ b/scripts/install-local-bio-connectors.sh
@@ -1,0 +1,262 @@
+#!/bin/zsh
+# Register local stdio replacements for the hosted HCLS directory connectors
+# that require a real Anthropic session in Claude Science.
+#
+# What it does, idempotently:
+#   1. Adds local-stdio connectors for PubMed, ClinicalTrials.gov, ChEMBL, bioRxiv.
+#   2. Attaches those local connectors to the target agent (default: OPERON).
+#   3. Detaches the failing hosted bundled connectors from that agent so tool
+#      routing does not prefer the remote *.mcp.claude.com entries.
+#
+# It only talks to the CSSwitch sandbox daemon API and refuses the real
+# ~/.claude-science data-dir.
+
+set -euo pipefail
+
+BIN="/Applications/Claude Science.app/Contents/Resources/bin/claude-science"
+PORT=8990
+DATA_DIR="$HOME/.csswitch/sandbox/home/.claude-science"
+AGENT="OPERON"
+
+usage() {
+  cat <<EOF
+Usage: scripts/install-local-bio-connectors.sh [options]
+
+Options:
+  --data-dir DIR      Claude Science sandbox data-dir (default: $DATA_DIR)
+  --port PORT         Sandbox daemon port (default: $PORT)
+  --agent NAME        Agent to attach local connectors to (default: $AGENT)
+  --bin PATH          claude-science binary path (default: $BIN)
+  -h, --help          Show this help
+
+Run this after CSSwitch has started its Claude Science sandbox.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --data-dir) DATA_DIR="$2"; shift 2;;
+    --port) PORT="$2"; shift 2;;
+    --agent) AGENT="$2"; shift 2;;
+    --bin) BIN="$2"; shift 2;;
+    -h|--help) usage; exit 0;;
+    *) echo "未知参数: $1" >&2; usage >&2; exit 2;;
+  esac
+done
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "缺少命令: $1" >&2
+    exit 127
+  }
+}
+
+need curl
+need python3
+
+[[ "$PORT" =~ ^[0-9]+$ ]] || { echo "拒绝：端口不是整数：$PORT" >&2; exit 2; }
+if (( 10#$PORT == 8765 )); then
+  echo "拒绝：端口 8765 是真实 Claude Science 实例保留端口。" >&2
+  exit 2
+fi
+
+DATA_DIR="${DATA_DIR:A}"
+REAL_DIR="$HOME/.claude-science"
+if [[ "$DATA_DIR" == "${REAL_DIR:A}" ]]; then
+  echo "拒绝：data-dir 指向真实 ~/.claude-science。" >&2
+  exit 2
+fi
+if [[ ! -d "$DATA_DIR" ]]; then
+  echo "找不到 data-dir：$DATA_DIR" >&2
+  echo "请先在 CSSwitch 里启动 Claude Science 沙箱。" >&2
+  exit 1
+fi
+if [[ ! -x "$BIN" ]]; then
+  echo "找不到 claude-science 二进制：$BIN" >&2
+  exit 1
+fi
+
+SANDBOX_HOME="${DATA_DIR:h}"
+API_BASE="http://127.0.0.1:$PORT/api"
+ORIGIN="http://localhost:$PORT"
+
+if ! curl -fsS --max-time 3 "http://127.0.0.1:$PORT/health" >/dev/null; then
+  echo "Claude Science 沙箱未在端口 $PORT 响应。请先启动 CSSwitch。" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/csswitch-local-bio.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+first_http_url() {
+  python3 -c 'import re,sys; s=sys.stdin.read(); m=re.search(r"https?://\S+", s); print(m.group(0) if m else "")'
+}
+
+echo "获取本地 daemon 会话 cookie（single-use URL 只在本脚本内消费）…"
+URL_OUT="$(HOME="$SANDBOX_HOME" "$BIN" url --data-dir "$DATA_DIR")"
+URL="$(printf '%s\n' "$URL_OUT" | first_http_url)"
+if [[ -z "$URL" ]]; then
+  echo "无法从 claude-science url 输出中解析入口 URL：" >&2
+  printf '%s\n' "$URL_OUT" >&2
+  exit 1
+fi
+
+curl -fsS -D "$TMP_DIR/headers.txt" -o "$TMP_DIR/login.html" "$URL"
+
+read AUTH CSRF < <(python3 - "$TMP_DIR/headers.txt" <<'PY'
+import re, sys
+headers = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+def cookie(name):
+    m = re.search(rf"(?im)^set-cookie:\s*{re.escape(name)}=([^;]+)", headers)
+    return m.group(1) if m else ""
+print(cookie("operon_auth"), cookie("operon_csrf"))
+PY
+)
+
+if [[ -z "$AUTH" || -z "$CSRF" ]]; then
+  echo "未取得 operon_auth / operon_csrf cookie；本地登录链接可能已被消费。" >&2
+  exit 1
+fi
+
+api() {
+  local method="$1"
+  local api_path="$2"
+  local data="${3:-}"
+  local -a args
+  args=(-fsS --max-time 120 -X "$method"
+    -H "Cookie: operon_auth=$AUTH; operon_csrf=$CSRF"
+    -H "x-operon-csrf: $CSRF"
+    -H "Origin: $ORIGIN"
+    -H "Referer: $ORIGIN/"
+    -H "Content-Type: application/json")
+  if [[ -n "$data" ]]; then
+    args+=(--data "$data")
+  fi
+  command curl "${args[@]}" "$API_BASE$api_path"
+}
+
+json_body() {
+  local name="$1" pkg="$2" desc="$3" py="$4" run="$5"
+  python3 - "$name" "$pkg" "$desc" "$py" "$run" <<'PY'
+import json, sys
+name, pkg, desc, py, run = sys.argv[1:]
+print(json.dumps({
+    "name": name,
+    "command": py,
+    "args": [run, pkg],
+    "env": {},
+    "description": desc,
+}, ensure_ascii=False))
+PY
+}
+
+urlenc() {
+  python3 - "$1" <<'PY'
+import sys, urllib.parse
+print(urllib.parse.quote(sys.argv[1], safe=""))
+PY
+}
+
+connector_exists() {
+  local name="$1" file="$2"
+  python3 - "$name" "$file" <<'PY'
+import json, sys
+name, file = sys.argv[1:]
+items = json.load(open(file))
+sys.exit(0 if any(c.get("name") == name for c in items) else 1)
+PY
+}
+
+RUNTIME_DIR="$(find "$DATA_DIR/runtime" -maxdepth 1 -type d -name '*release' | head -n1)"
+PYTHON_BIN="$DATA_DIR/conda/envs/operon-mcp/bin/python"
+RUN_SERVER="$RUNTIME_DIR/mcp-servers/bio-tools/run_server.py"
+
+if [[ -z "$RUNTIME_DIR" || ! -f "$RUN_SERVER" ]]; then
+  echo "找不到 bio-tools run_server.py；data-dir 可能未完成初始化：$DATA_DIR" >&2
+  exit 1
+fi
+if [[ ! -x "$PYTHON_BIN" ]]; then
+  echo "找不到 operon-mcp Python：$PYTHON_BIN" >&2
+  exit 1
+fi
+
+echo "读取现有 connector 列表…"
+api GET "/mcp-servers/connectors" > "$TMP_DIR/connectors-before.json"
+
+typeset -a CONNECTORS
+CONNECTORS=(
+  "pubmed-local|mcp_pubmed|Local PubMed connector backed by NCBI E-utilities and Europe PMC full text"
+  "clinical-trials-local|mcp_clinical_trials|Local ClinicalTrials.gov connector"
+  "chembl-local|mcp_chembl|Local ChEMBL connector"
+  "biorxiv-local|mcp_biorxiv|Local bioRxiv/medRxiv connector"
+)
+
+for row in "${CONNECTORS[@]}"; do
+  IFS='|' read -r name pkg desc <<< "$row"
+  if connector_exists "$name" "$TMP_DIR/connectors-before.json"; then
+    echo "已存在：$name"
+  else
+    echo "创建本地 connector：$name"
+    body="$(json_body "$name" "$pkg" "$desc" "$PYTHON_BIN" "$RUN_SERVER")"
+    api POST "/mcp-servers/local" "$body" >/dev/null
+  fi
+
+  local_id="local:$name"
+  encoded_id="$(urlenc "$local_id")"
+  echo "挂载到 agent：$AGENT <- $local_id"
+  api POST "/mcp-servers/$encoded_id/attach" "$(python3 - "$AGENT" <<'PY'
+import json, sys
+print(json.dumps({"agent_names": [sys.argv[1]]}))
+PY
+)" >/dev/null
+done
+
+typeset -a REMOTES
+REMOTES=(
+  "bundled:pubmed"
+  "bundled:clinical-trials"
+  "bundled:chembl"
+  "bundled:biorxiv"
+)
+
+for remote_id in "${REMOTES[@]}"; do
+  encoded_id="$(urlenc "$remote_id")"
+  echo "从 agent 卸载官方远端 connector（保留目录记录）：$AGENT -/-> $remote_id"
+  api DELETE "/mcp-servers/$encoded_id/agents/$AGENT" >/dev/null || true
+done
+
+echo
+echo "验证 $AGENT 的本地 bio connector 工具清单…"
+api GET "/agents/$AGENT/mcp-servers?include_tools=true" > "$TMP_DIR/agent-mcp.json"
+python3 - "$TMP_DIR/agent-mcp.json" <<'PY'
+import json, sys
+items = json.load(open(sys.argv[1]))
+wanted = {"pubmed-local", "clinical-trials-local", "chembl-local", "biorxiv-local"}
+seen = {}
+for item in items:
+    name = item.get("name")
+    if name in wanted:
+        seen[name] = item
+
+missing = sorted(wanted - seen.keys())
+if missing:
+    print("缺少本地 connector:", ", ".join(missing), file=sys.stderr)
+    sys.exit(1)
+
+bad = []
+for name in sorted(wanted):
+    item = seen[name]
+    tools = item.get("tools") or []
+    ok = item.get("is_connected") is True and len(tools) > 0
+    print(f"{name}: connected={item.get('is_connected')} tools={len(tools)}")
+    if not ok:
+        bad.append(name)
+
+if bad:
+    print("以下 connector 未连接或工具为空:", ", ".join(bad), file=sys.stderr)
+    sys.exit(1)
+PY
+
+echo
+echo "完成。Directory 页面里的官方远端 PubMed/ChEMBL 等仍可能显示 Failed；"
+echo "这是虚拟登录下的预期 UI 状态，不影响 $AGENT 使用上面的本地 *-local 工具。"


### PR DESCRIPTION
## Summary

- add an idempotent `scripts/install-local-bio-connectors.sh` helper that registers local stdio replacements for PubMed, Clinical Trials, ChEMBL, and bioRxiv
- attach the local `*-local` connectors to `OPERON` and detach the failing hosted `bundled:*` entries from that agent to avoid tool-routing failures
- document why the Directory entries can still show `Failed` under virtual OAuth and how to verify the local connectors

## Why

Under CSSwitch virtual OAuth, Anthropic-hosted HCLS connectors require a real claude.ai org/session and can show `Failed`. Claude Science already ships local `bio-tools` stdio servers for the same domains, so this gives users a repeatable local repair path instead of asking them to hand-add local MCP commands.

## Validation

- `zsh -n scripts/install-local-bio-connectors.sh`
- `scripts/install-local-bio-connectors.sh` against a running CSSwitch sandbox
- `bash test/run_all.sh`
- `cargo test` in `desktop/src-tauri`
