### PR TITLE
fix: /health 端点免鉴权，避免代理探活因 secret 不一致误判为不健康

### DIFF
--- a/proxy/csswitch_proxy.py
+++ b/proxy/csswitch_proxy.py
@@ -360,6 +360,12 @@ class H(BaseHTTPRequestHandler):
         return False
 
     def do_GET(self):
+        # /health 免鉴权（健康检查不含敏感信息）
+        # 注意：path 可能尚未经 _auth_ok 剥离前缀，故同时匹配裸路径和带 secret 前缀的路径。
+        if self.path == "/health" or self.path.startswith("/health?") \
+           or self.path.endswith("/health") or "/health?" in self.path:
+            self._send_json(200, {"status": "ok", "provider": PROV_NAME})
+            return
         if not self._auth_ok():
             return
         if self.path.startswith("/v1/models"):
@@ -368,8 +374,6 @@ class H(BaseHTTPRequestHandler):
             log(f"GET /v1/models -> {PROV_NAME}: {', '.join(m[0] for m in PROV['models'])}")
             self._send_json(200, {"data": data, "has_more": False,
                                   "first_id": data[0]["id"], "last_id": data[-1]["id"]})
-        elif self.path.startswith("/health"):
-            self._send_json(200, {"status": "ok", "provider": PROV_NAME})
         else:
             self._send_json(404, {"type": "error", "error": {"type": "not_found_error", "message": self.path}})
 

--- a/test/test_proxy_auth.py
+++ b/test/test_proxy_auth.py
@@ -61,9 +61,10 @@ class ProxyAuth(unittest.TestCase):
         s, _b = _req(f"{self.base}/{SEC}/health")
         self.assertEqual(s, 200)
 
-    def test_health_without_secret_forbidden(self):
+    def test_health_without_secret_ok(self):
+        # /health 免鉴权（自 #12 起），便于监控探活不依赖 secret 一致性
         s, _b = _req(f"{self.base}/health")
-        self.assertEqual(s, 403)
+        self.assertEqual(s, 200)
 
     def test_messages_without_secret_forbidden_and_upstream_untouched(self):
         before = len(self.hits)


### PR DESCRIPTION
## 解决的问题

Closes #12

## 问题描述

`/health` 端点要求 path-secret 鉴权。当 `config.secret` 被清空或轮换后，所有现有的监控探活（Rust 侧 `status()` 命令、面板状态灯）全部返回 403 → 误判代理不健康 → 状态灯黄灯。实际上代理正在正常运行，只是 secret 不一致。

## 修改

- `/health` 改为免鉴权。健康检查仅返回 `{"status":"ok","provider":"deepseek"}`，不含密钥、令牌或任何敏感信息，加鉴权反而引入脆弱性
- 同时匹配裸路径 `/health` 和带 secret 前缀的路径 `/<secret>/health`，兼容新旧调用方
- 测试更新：`test_health_without_secret_forbidden` → `test_health_without_secret_ok`，期望值从 403 改为 200

## 验证

```bash
# 全量测试通过
bash test/run_all.sh
# ALL GREEN
```

## 影响范围

- 向后兼容：带 secret 前缀的 `/health` 请求仍正常返回 200
- 安全面无退化：`/health` 不含敏感数据，`/v1/messages` 与 `/v1/models` 仍受 secret 保护
- Rust 侧 `proc::http_health()` 无需修改（仍可带或不带 secret 调用）