### PR TITLE
[codex] Support custom OpenAI Responses providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,20 @@
 
 ## [Unreleased]
 
+## [0.3.6] — 2026-07-06
+
+> 主题：**自定义 OpenAI Responses provider 预览支持**。这版新增 OpenAI Responses 兼容端点路径，并针对 DashScope Responses 兼容模式收紧工具调用与输出预算边界。
+
 ### 新增 Added
 - **自定义 OpenAI Responses 兼容端点**：新增「自定义 OpenAI Responses」来源，用户填写 OpenAI 兼容 base root、模型与 key 后，代理自动拼接 `/responses` 与 `/models`，并在 Anthropic Messages 与 OpenAI Responses 之间做基础转换。
 
+### 修复 Fixed
+- **DashScope Responses 工具请求稳定性**：带工具的 Responses 请求会保守降级强制工具选择并收紧输出预算，避免兼容层因工具选择或过大输出预算拒绝请求。
+- **DashScope Responses 工具 schema 兼容性**：过滤当前兼容模式不接受的内置搜索工具定义，并对工具参数根 schema 做保守归一化，避免整个请求被上游 schema 校验拒绝。
+
 ### 说明 Notes
 - Responses 路径当前以非流式上游请求完成后本地回放 Anthropic SSE，尚不宣称原生 Responses SSE 增量转换。
-- Responses 路径会对 `max_output_tokens` 应用 65536 上限，并将强制工具选择保守降级为 `auto`，以兼容更严格的 Responses 兼容端点。
+- Responses 路径会对 `max_output_tokens` 应用上限，并将强制工具选择保守降级为 `auto`，以兼容更严格的 Responses 兼容端点；DashScope 工具请求使用更保守的预算。
 
 ## [0.3.5] — 2026-07-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 > **约定**：已修问题从 [`docs/known-issues.md`](docs/known-issues.md)「毕业」到这里（发布即定稿）；未修/进行中留在 known-issues；硬 bug 的根因证据链存在 [`findings/`](findings/)。
 
+## [Unreleased]
+
+### 新增 Added
+- **自定义 OpenAI Responses 兼容端点**：新增「自定义 OpenAI Responses」来源，用户填写 OpenAI 兼容 base root、模型与 key 后，代理自动拼接 `/responses` 与 `/models`，并在 Anthropic Messages 与 OpenAI Responses 之间做基础转换。
+
+### 说明 Notes
+- Responses 路径当前以非流式上游请求完成后本地回放 Anthropic SSE，尚不宣称原生 Responses SSE 增量转换。
+- Responses 路径会对 `max_output_tokens` 应用 65536 上限，并将强制工具选择保守降级为 `auto`，以兼容更严格的 Responses 兼容端点。
+
 ## [0.3.5] — 2026-07-06
 
 > 主题：**API/provider 稳定性基线**。这版把 Anthropic 兼容 provider 的关键路径拆清楚，强化 Kimi / DeepSeek / 自定义 Anthropic 等路径的流式、错误与工具调用兼容性，作为后续 provider capability / matrix 工作的稳定底座。

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "desktop",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "desktop",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "devDependencies": {
         "@tauri-apps/cli": "^2"
       }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "desktop",
   "private": true,
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
   "scripts": {
     "tauri": "tauri"

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "desktop"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "desktop"
-version = "0.3.5"
+version = "0.3.6"
 description = "CSSwitch 菜单栏 app（进程管家 + 配置面板）"
 authors = ["CSSwitch"]
 edition = "2021"

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@
 //! Python/Node/shell 里被当作子进程调用，以保住铁律护栏与已验证行为。
 //!
 //! 运行行为由生效 profile 的 `template_id` 经 [`templates`] 注册表派生出 adapter
-//! （deepseek | qwen | relay | openai-custom），再传给 python 代理 `--provider`。
+//! （deepseek | qwen | relay | openai-custom | openai-responses），再传给 python 代理 `--provider`。
 //!
 //! 铁律相关：key 只在内存与 0600 的 config.json；回显前端只给掩码；沙箱端口/目录护栏
 //! 由被调脚本负责（对 8765 与真实目录失败关闭）；退 app 默认停代理、保留沙箱。
@@ -35,7 +35,7 @@ struct AppState {
     proxy: Option<Child>,
     proxy_port: u16,
     secret: String,
-    /// 当前代理进程所用 adapter 名（deepseek | qwen | relay | openai-custom）；用于健康复用判定。
+    /// 当前代理进程所用 adapter 名（deepseek | qwen | relay | openai-custom | openai-responses）；用于健康复用判定。
     provider: String,
     /// 当前代理进程所用 key 的非加密指纹（仅内存、绝不落盘/打印）。
     /// 换 key/换上游后指纹变化 → 触发重启，避免复用带旧配置的代理。
@@ -59,7 +59,7 @@ fn key_env_for_adapter(adapter: &str) -> &'static str {
     match adapter {
         "deepseek" => "DEEPSEEK_API_KEY",
         "qwen" => "DASHSCOPE_API_KEY",
-        "openai-custom" => "CSSWITCH_OPENAI_KEY",
+        "openai-custom" | "openai-responses" => "CSSWITCH_OPENAI_KEY",
         _ => "CSSWITCH_RELAY_KEY", // relay / 兜底
     }
 }
@@ -100,12 +100,12 @@ fn proxy_fingerprint(p: &config::Profile, launch: &ProxyLaunch) -> u64 {
     ))
 }
 
-/// 本轨仅支持 anthropic / openai_chat；其余进 schema 但激活拒绝（待轨道 2：Rust 代理）。
+/// 本轨支持 anthropic / openai_chat / openai_responses；其余进 schema 但激活拒绝（待轨道 2：Rust 代理）。
 fn assert_format_supported(p: &config::Profile) -> Result<(), String> {
     match p.api_format.as_str() {
-        "anthropic" | "openai_chat" => Ok(()),
+        "anthropic" | "openai_chat" | "openai_responses" => Ok(()),
         other => Err(format!(
-            "api_format `{other}` 暂不支持（待 Rust 代理），请选 anthropic 或 openai_chat。"
+            "api_format `{other}` 暂不支持（待 Rust 代理），请选 anthropic、openai_chat 或 openai_responses。"
         )),
     }
 }
@@ -116,7 +116,9 @@ fn looks_like_anthropic_endpoint(base_url: &str) -> bool {
 }
 
 fn reject_openai_custom_anthropic_base(template_id: &str, base_url: &str) -> Result<(), String> {
-    if template_id == "custom-openai" && looks_like_anthropic_endpoint(base_url) {
+    if matches!(template_id, "custom-openai" | "custom-openai-responses")
+        && looks_like_anthropic_endpoint(base_url)
+    {
         Err("这个地址看起来是 Anthropic 兼容端点。请改选「自定义 Anthropic」，或使用 OpenAI 兼容 base root（如 https://api.moonshot.cn/v1）。".to_string())
     } else {
         Ok(())
@@ -128,8 +130,8 @@ fn is_native_adapter(adapter: &str) -> bool {
     adapter == "deepseek" || adapter == "qwen"
 }
 
-fn is_openai_custom_adapter(adapter: &str) -> bool {
-    adapter == "openai-custom"
+fn is_openai_adapter(adapter: &str) -> bool {
+    matches!(adapter, "openai-custom" | "openai-responses")
 }
 
 /// 上游主机名（供 status 上游灯做 TCP 可达性探测）。relay 家族从其 base_url 解析。
@@ -465,7 +467,7 @@ fn start_proxy_for(
             .env(launch.key_env, &launch.key);
         // 非 native 家族：base_url + 选中模型经环境变量交给代理（均非密钥，但与 key 一致走 env）。
         if !native {
-            if is_openai_custom_adapter(&launch.adapter) {
+            if is_openai_adapter(&launch.adapter) {
                 cmd.env("CSSWITCH_OPENAI_BASE_URL", &launch.base_url);
                 if !launch.model.is_empty() {
                     cmd.env("CSSWITCH_OPENAI_MODEL", &launch.model);
@@ -2053,6 +2055,20 @@ mod tests {
         assert_eq!(c.key_env, "CSSWITCH_OPENAI_KEY");
         assert_eq!(c.base_url, "https://open.bigmodel.cn/api/paas/v4");
         assert_eq!(c.model, "glm-4.5");
+
+        let custom_responses = Profile {
+            template_id: "custom-openai-responses".into(),
+            api_format: "openai_responses".into(),
+            base_url: "https://api.openai.com/v1".into(),
+            api_key: "ok".into(),
+            model: "gpt-5.2".into(),
+            ..Default::default()
+        };
+        let d = proxy_args_for(&custom_responses);
+        assert_eq!(d.adapter, "openai-responses");
+        assert_eq!(d.key_env, "CSSWITCH_OPENAI_KEY");
+        assert_eq!(d.base_url, "https://api.openai.com/v1");
+        assert_eq!(d.model, "gpt-5.2");
     }
 
     #[test]
@@ -2076,6 +2092,11 @@ mod tests {
             ..p
         };
         assert!(assert_format_supported(&ok2).is_ok());
+        let ok3 = Profile {
+            api_format: "openai_responses".into(),
+            ..ok2
+        };
+        assert!(assert_format_supported(&ok3).is_ok());
     }
 
     #[test]
@@ -2090,6 +2111,11 @@ mod tests {
             reject_openai_custom_anthropic_base("custom-openai", "https://api.moonshot.cn/v1",)
                 .is_ok()
         );
+        assert!(reject_openai_custom_anthropic_base(
+            "custom-openai-responses",
+            "https://api.moonshot.cn/anthropic",
+        )
+        .is_err());
         assert!(
             reject_openai_custom_anthropic_base("custom", "https://api.moonshot.cn/anthropic",)
                 .is_ok()
@@ -2101,6 +2127,10 @@ mod tests {
         assert_eq!(key_env_for_adapter("deepseek"), "DEEPSEEK_API_KEY");
         assert_eq!(key_env_for_adapter("qwen"), "DASHSCOPE_API_KEY");
         assert_eq!(key_env_for_adapter("openai-custom"), "CSSWITCH_OPENAI_KEY");
+        assert_eq!(
+            key_env_for_adapter("openai-responses"),
+            "CSSWITCH_OPENAI_KEY"
+        );
         assert_eq!(key_env_for_adapter("relay"), "CSSWITCH_RELAY_KEY");
         assert_eq!(key_env_for_adapter("anything-else"), "CSSWITCH_RELAY_KEY");
     }
@@ -2406,11 +2436,12 @@ mod tests {
     }
 
     #[test]
-    fn list_templates_has_ten() {
+    fn list_templates_has_eleven() {
         let v = build_list_templates();
-        assert_eq!(v.len(), 10);
+        assert_eq!(v.len(), 11);
         assert!(v.iter().any(|t| t["id"] == "custom"));
         assert!(v.iter().any(|t| t["id"] == "custom-openai"));
+        assert!(v.iter().any(|t| t["id"] == "custom-openai-responses"));
         assert!(v.iter().any(|t| t["id"] == "kimi"));
         assert!(v.iter().any(|t| t["id"] == "minimax"));
     }

--- a/desktop/src-tauri/src/scratch.rs
+++ b/desktop/src-tauri/src/scratch.rs
@@ -87,7 +87,7 @@ pub fn scratch_env(
 ) -> Vec<(String, String)> {
     let mut v = vec![(key_env.to_string(), key.to_string())];
     if !base_url.is_empty() {
-        let env = if provider == "openai-custom" {
+        let env = if matches!(provider, "openai-custom" | "openai-responses") {
             "CSSWITCH_OPENAI_BASE_URL"
         } else {
             "CSSWITCH_RELAY_BASE_URL"
@@ -96,7 +96,7 @@ pub fn scratch_env(
     }
     if let Some(m) = model {
         if !m.is_empty() {
-            let env = if provider == "openai-custom" {
+            let env = if matches!(provider, "openai-custom" | "openai-responses") {
                 "CSSWITCH_OPENAI_MODEL"
             } else {
                 "CSSWITCH_RELAY_MODEL"
@@ -104,7 +104,7 @@ pub fn scratch_env(
             v.push((env.to_string(), m.to_string()));
         }
     }
-    if provider != "openai-custom" && !relay_thinking.is_empty() {
+    if !matches!(provider, "openai-custom" | "openai-responses") && !relay_thinking.is_empty() {
         v.push((
             "CSSWITCH_RELAY_THINKING".to_string(),
             relay_thinking.to_string(),
@@ -324,6 +324,29 @@ mod tests {
                     "https://open.bigmodel.cn/api/paas/v4".to_string()
                 ),
                 ("CSSWITCH_OPENAI_MODEL".to_string(), "glm-4.5".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn scratch_env_openai_responses_sets_openai_base_and_model() {
+        let env = scratch_env(
+            "openai-responses",
+            "CSSWITCH_OPENAI_KEY",
+            "sk-z",
+            "https://api.openai.com/v1",
+            Some("gpt-5.2"),
+            "enabled",
+        );
+        assert_eq!(
+            env,
+            vec![
+                ("CSSWITCH_OPENAI_KEY".to_string(), "sk-z".to_string()),
+                (
+                    "CSSWITCH_OPENAI_BASE_URL".to_string(),
+                    "https://api.openai.com/v1".to_string()
+                ),
+                ("CSSWITCH_OPENAI_MODEL".to_string(), "gpt-5.2".to_string()),
             ]
         );
     }

--- a/desktop/src-tauri/src/templates.rs
+++ b/desktop/src-tauri/src/templates.rs
@@ -8,7 +8,7 @@ pub struct Template {
     pub name: &'static str,
     pub category: &'static str,   // official | cn_official | custom
     pub api_format: &'static str, // anthropic | openai_chat | openai_responses | gemini_native
-    pub adapter: &'static str, // 运行行为 → python 代理 --provider：deepseek | qwen | relay | openai-custom
+    pub adapter: &'static str, // 运行行为 → python 代理 --provider：deepseek | qwen | relay | openai-custom | openai-responses
     pub base_url: &'static str, // 默认；空=用户填
     pub base_url_editable: bool,
     pub requires_model_override: bool,
@@ -196,6 +196,21 @@ static TEMPLATES: &[Template] = &[
         thinking_policy: "",
     },
     Template {
+        id: "custom-openai-responses",
+        name: "自定义 OpenAI Responses",
+        category: "custom",
+        api_format: "openai_responses",
+        adapter: "openai-responses",
+        base_url: "",
+        base_url_editable: true,
+        requires_model_override: true,
+        builtin_models: &[],
+        website_url: "",
+        icon: "custom",
+        icon_color: "#0F766E",
+        thinking_policy: "",
+    },
+    Template {
         id: "custom",
         name: "自定义 Anthropic",
         category: "custom",
@@ -258,7 +273,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     #[test]
-    fn table_has_ten_templates() {
+    fn table_has_eleven_templates() {
         let ids: Vec<&str> = all().iter().map(|t| t.id).collect();
         assert_eq!(
             ids,
@@ -272,6 +287,7 @@ mod tests {
                 "openrouter",
                 "qwen",
                 "custom-openai",
+                "custom-openai-responses",
                 "custom"
             ]
         );
@@ -286,6 +302,7 @@ mod tests {
         assert_eq!(adapter_for("minimax"), "relay");
         assert_eq!(adapter_for("openrouter"), "relay");
         assert_eq!(adapter_for("custom-openai"), "openai-custom");
+        assert_eq!(adapter_for("custom-openai-responses"), "openai-responses");
         assert_eq!(adapter_for("custom"), "relay");
         assert_eq!(adapter_for("unknown-xyz"), "relay"); // 兜底
     }
@@ -298,6 +315,10 @@ mod tests {
         assert_eq!(by_id("minimax").unwrap().api_format, "anthropic");
         assert_eq!(by_id("qwen").unwrap().api_format, "openai_chat");
         assert_eq!(by_id("custom-openai").unwrap().api_format, "openai_chat");
+        assert_eq!(
+            by_id("custom-openai-responses").unwrap().api_format,
+            "openai_responses"
+        );
         assert_eq!(by_id("custom").unwrap().api_format, "anthropic");
     }
 
@@ -309,6 +330,11 @@ mod tests {
         assert!(by_id("minimax").unwrap().requires_model_override);
         assert!(by_id("glm").unwrap().requires_model_override); // 改：全 relay 统一 force
         assert!(by_id("custom-openai").unwrap().requires_model_override);
+        assert!(
+            by_id("custom-openai-responses")
+                .unwrap()
+                .requires_model_override
+        );
         assert!(by_id("openrouter").unwrap().requires_model_override); // 改
         assert!(by_id("custom").unwrap().requires_model_override);
         // 旗舰默认 = builtin_models 首项（官方核定，2026-07-04）
@@ -370,6 +396,8 @@ mod tests {
             "kimi",
             "minimax",
             "openrouter",
+            "custom-openai",
+            "custom-openai-responses",
             "custom",
         ] {
             assert!(

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "CSSwitch",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "identifier": "com.csswitch.menubar",
   "build": {
     "frontendDist": "../src"

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -27,6 +27,7 @@ const MOCK_TEMPLATES = [
   { id: "openrouter", name: "OpenRouter", category: "custom", api_format: "anthropic", adapter: "relay", base_url: "https://openrouter.ai/api", base_url_editable: true, requires_model_override: true, builtin_models: ["anthropic/claude-sonnet-5", "anthropic/claude-opus-4.8", "anthropic/claude-opus-4.8-fast"], icon: "openrouter", icon_color: "#6467F2", website_url: "https://openrouter.ai" },
   { id: "qwen", name: "通义千问", category: "cn_official", api_format: "openai_chat", adapter: "qwen", base_url: "https://dashscope.aliyuncs.com/compatible-mode/v1", base_url_editable: false, requires_model_override: false, builtin_models: ["qwen-max", "qwen-plus", "qwen-turbo"], icon: "qwen", icon_color: "#615CED", website_url: "https://dashscope.aliyun.com" },
   { id: "custom-openai", name: "自定义 OpenAI", category: "custom", api_format: "openai_chat", adapter: "openai-custom", base_url: "", base_url_editable: true, requires_model_override: true, builtin_models: [], icon: "custom", icon_color: "#2563EB", website_url: "" },
+  { id: "custom-openai-responses", name: "自定义 OpenAI Responses", category: "custom", api_format: "openai_responses", adapter: "openai-responses", base_url: "", base_url_editable: true, requires_model_override: true, builtin_models: [], icon: "custom", icon_color: "#0F766E", website_url: "" },
   { id: "custom", name: "自定义 Anthropic", category: "custom", api_format: "anthropic", adapter: "relay", base_url: "", base_url_editable: true, requires_model_override: true, builtin_models: [], icon: "custom", icon_color: "#6B7280", website_url: "" },
 ];
 const mockStore = {
@@ -140,7 +141,10 @@ function sourceHint(t) {
   if (!t) return "选择来源后按提示填写。";
   // 真·自定义（可编辑且无预设地址）才叫「自定义端点」；预设虽可编辑但有官方默认，另行描述。
   if (t.base_url_editable && !t.base_url && t.api_format === "openai_chat") {
-    return "自定义 OpenAI 兼容端点：填 base root、key 与模型，经代理转换协议。";
+    return "自定义 OpenAI Chat Completions 兼容端点：填 base root、key 与模型，经代理转换协议。";
+  }
+  if (t.base_url_editable && !t.base_url && t.api_format === "openai_responses") {
+    return "自定义 OpenAI Responses 兼容端点：填 base root、key 与模型，经代理转换协议。";
   }
   if (t.base_url_editable && !t.base_url) return "自定义 Anthropic 兼容端点：填地址与 key，用「获取模型」列出并选一个。";
   const cap = modelCapability(t);
@@ -498,13 +502,15 @@ function onWizTemplate() {
     // 预设：预填官方默认地址（仍可改到套餐 / 区域端点）；真·自定义：留空 + 占位提示。
     els.wizBase.value = t.base_url || "";
     els.wizBase.readOnly = false;
-    els.wizBase.placeholder = t.api_format === "openai_chat"
+    els.wizBase.placeholder = t.api_format === "openai_chat" || t.api_format === "openai_responses"
       ? "https://open.bigmodel.cn/api/paas/v4"
       : "https://your-relay/claude";
     els.wizBaseHint.textContent = t.base_url
       ? "官方默认地址，可改到 token 套餐 / 区域端点（如小米 token plan）。"
       : (t.api_format === "openai_chat"
         ? "OpenAI 兼容 base root，代理自动补 /chat/completions 与 /models。"
+        : t.api_format === "openai_responses"
+        ? "OpenAI 兼容 base root，代理自动补 /responses 与 /models。"
         : "自定义端点根地址（自动补 /v1/messages 与 /v1/models）。");
   } else {
     els.wizBase.value = t.base_url;
@@ -524,7 +530,7 @@ function refreshWizGate() {
 }
 
 function openaiCustomAnthropicBaseMessage(t, base) {
-  if (t && t.id === "custom-openai" && (base || "").trim().toLowerCase().includes("/anthropic")) {
+  if (t && (t.id === "custom-openai" || t.id === "custom-openai-responses") && (base || "").trim().toLowerCase().includes("/anthropic")) {
     return "这个地址看起来是 Anthropic 兼容端点。请改选「自定义 Anthropic」，或填写 OpenAI 兼容 base root（如 https://api.moonshot.cn/v1）。";
   }
   return "";
@@ -599,7 +605,7 @@ function openConn(id) {
   els.connTitle.textContent = "编辑连接 · " + p.name + (active ? "（当前生效）" : "");
   els.connBase.value = p.base_url || (t ? t.base_url : "");
   els.connBase.readOnly = !editable;
-  els.connBase.placeholder = t && t.api_format === "openai_chat"
+  els.connBase.placeholder = t && (t.api_format === "openai_chat" || t.api_format === "openai_responses")
     ? "https://open.bigmodel.cn/api/paas/v4"
     : "https://your-relay/claude";
   // native（deepseek/qwen）隐藏「获取模型」按钮，别再提示一个不存在的操作（修 #5）。
@@ -608,6 +614,8 @@ function openConn(id) {
         ? "官方默认地址，可改到 token 套餐 / 区域端点。"
         : (t && t.api_format === "openai_chat"
           ? "OpenAI 兼容 base root，代理自动补 /chat/completions。"
+          : t && t.api_format === "openai_responses"
+          ? "OpenAI 兼容 base root，代理自动补 /responses。"
           : "自定义端点根地址。"))
     : (modelCapability(t) === CAP.NATIVE
         ? "模板地址（只读），模型由内置映射自动选择。"

--- a/docs/provider-capability-matrix.md
+++ b/docs/provider-capability-matrix.md
@@ -1,0 +1,15 @@
+# Provider Capability Matrix
+
+本文只记录公开代码层面的 provider 能力边界，供后续开发和 PR 摘要引用。它不记录测试环境、密钥、账号、路径或私有实现细节。
+
+| Family | Templates | Adapter | Upstream API | Endpoint handling | Model handling | Tool handling | Streaming behavior |
+|---|---|---|---|---|---|---|---|
+| Anthropic-compatible native | DeepSeek and compatible relay presets | `deepseek` / `relay` | Anthropic Messages | Uses provider base URL and `/v1/messages` / `/v1/models` conventions | Native mapping or selected relay model | Preserves Anthropic tool blocks, with provider-specific policy filters where configured | Proxies upstream SSE, with local keepalive/error handling |
+| OpenAI Chat compatible | Qwen and custom OpenAI Chat | `qwen` / `openai-custom` | Chat Completions | Base root derives `/chat/completions` and `/models` | Forces selected model when configured | Converts Anthropic tools to Chat Completions tools and maps tool calls back | Uses non-streaming upstream response with local Anthropic SSE replay |
+| OpenAI Responses compatible | Custom OpenAI Responses | `openai-responses` | Responses | Base root derives `/responses` and `/models` | Forces selected model when configured; clamps `max_output_tokens` to 65536 | Converts Anthropic tools to Responses function tools; forced `tool` / `any` choices degrade to `auto` | Uses non-streaming upstream response with local Anthropic SSE replay |
+
+## Current Boundary
+
+- Responses support is a first compatibility slice, not a claim of full native Responses parity.
+- Native Responses SSE conversion remains future work.
+- Provider-specific behavior should continue moving toward explicit capability flags instead of broad assumptions shared by all providers.

--- a/proxy/csswitch_proxy.py
+++ b/proxy/csswitch_proxy.py
@@ -514,16 +514,33 @@ def map_responses_tool_choice(tc, tools):
     千问 Responses 在 thinking mode 下会拒绝 required/object 形态；Science 会在
     reviewing/agent 路径发送强制工具选择。这里保守降级为 auto，宁可不强制工具，
     也不要让整个请求 400。"""
-    if not isinstance(tc, dict):
-        return None
-    t = tc.get("type")
+    has_tools = bool(tools)
+    if isinstance(tc, str):
+        t = tc
+    elif isinstance(tc, dict):
+        t = tc.get("type")
+    else:
+        t = None
     if t == "auto":
         return "auto"
     if t == "none":
         return "none"
-    if t in ("tool", "any"):
+    if has_tools:
         return "auto"
     return None
+
+
+def responses_max_output_tokens(req, model, state, has_tools):
+    value = provider_policy.clamp_max_tokens(req.get("max_tokens"), model, state)
+    if not value:
+        return value
+    # DashScope Responses accepts 65536 for simple prompts, but real Science tool
+    # requests with very large inbound max_tokens can still fail its compatibility
+    # layer. Keep tool calls on the conservative budget used by the existing Qwen
+    # chat path.
+    if has_tools and "dashscope.aliyuncs.com" in (PROV.get("url") or ""):
+        return min(int(value), 8192)
+    return value
 
 
 def _as_text(value):
@@ -584,8 +601,9 @@ def anthropic_to_openai_responses(req):
     }
     if sys_prompt:
         out["instructions"] = sys_prompt
-    if req.get("max_tokens"):
-        out["max_output_tokens"] = provider_policy.clamp_max_tokens(req["max_tokens"], out["model"], _st)
+    max_output_tokens = responses_max_output_tokens(req, out["model"], _st, bool(req.get("tools")))
+    if max_output_tokens:
+        out["max_output_tokens"] = max_output_tokens
     if req.get("temperature") is not None:
         out["temperature"] = req["temperature"]
     if req.get("top_p") is not None:

--- a/proxy/csswitch_proxy.py
+++ b/proxy/csswitch_proxy.py
@@ -543,6 +543,42 @@ def responses_max_output_tokens(req, model, state, has_tools):
     return value
 
 
+def _is_dashscope_responses():
+    return PROV.get("api_format") == "openai_responses" and "dashscope.aliyuncs.com" in (PROV.get("url") or "")
+
+
+def normalize_responses_tool_parameters(schema):
+    if not isinstance(schema, dict):
+        return {"type": "object", "properties": {}}
+    out = dict(schema)
+    if "properties" in out and not out.get("type"):
+        out["type"] = "object"
+    if out.get("type") != "object":
+        return {"type": "object", "properties": {}}
+    if not isinstance(out.get("properties"), dict):
+        out["properties"] = {}
+    return out
+
+
+def map_responses_tools(tools):
+    out = []
+    for t in tools or []:
+        name = t.get("name")
+        if not name:
+            continue
+        # DashScope Responses currently rejects this function schema in
+        # compatibility mode; omit it rather than failing the entire request.
+        if _is_dashscope_responses() and name == "web_search":
+            continue
+        out.append({
+            "type": "function",
+            "name": name,
+            "description": t.get("description", ""),
+            "parameters": normalize_responses_tool_parameters(t.get("input_schema", {})),
+        })
+    return out
+
+
 def _as_text(value):
     if isinstance(value, str):
         return value
@@ -601,21 +637,17 @@ def anthropic_to_openai_responses(req):
     }
     if sys_prompt:
         out["instructions"] = sys_prompt
-    max_output_tokens = responses_max_output_tokens(req, out["model"], _st, bool(req.get("tools")))
+    tools = map_responses_tools(req.get("tools"))
+    max_output_tokens = responses_max_output_tokens(req, out["model"], _st, bool(tools))
     if max_output_tokens:
         out["max_output_tokens"] = max_output_tokens
     if req.get("temperature") is not None:
         out["temperature"] = req["temperature"]
     if req.get("top_p") is not None:
         out["top_p"] = req["top_p"]
-    if req.get("tools"):
-        out["tools"] = [{
-            "type": "function",
-            "name": t["name"],
-            "description": t.get("description", ""),
-            "parameters": t.get("input_schema", {}),
-        } for t in req["tools"] if t.get("name")]
-    tcm = map_responses_tool_choice(req.get("tool_choice"), req.get("tools"))
+    if tools:
+        out["tools"] = tools
+    tcm = map_responses_tool_choice(req.get("tool_choice"), tools)
     if tcm is not None:
         out["tool_choice"] = tcm
     return out

--- a/proxy/csswitch_proxy.py
+++ b/proxy/csswitch_proxy.py
@@ -8,6 +8,8 @@ Providers:
   qwen           ：DashScope compatible-mode —— Anthropic↔OpenAI 双向翻译（流式以 SSE 回放保真 tool_use）。
   openai-custom  ：任意 OpenAI Chat Completions 兼容端点，base_url + token + model。
                    代理拼 /chat/completions 与 /models，并复用 qwen 的 Anthropic↔OpenAI 翻译链。
+  openai-responses：任意 OpenAI Responses 兼容端点，base_url + token + model。
+                   代理拼 /responses 与 /models，并做 Anthropic↔Responses 翻译。
   relay          ：任意「中转站」（Anthropic 兼容端点，base_url + token）。原生透传、【不重映射模型】，
                    /v1/models 回源直拉让 Science 选择器自动铺满中转站真实模型。base_url 经
                    CSSWITCH_RELAY_BASE_URL 提供、token 经 CSSWITCH_RELAY_KEY 提供。
@@ -104,6 +106,7 @@ PROVIDERS = {
     },
     "openai-custom": {
         "mode": "openai",
+        "api_format": "openai_chat",
         "url": None,
         "models_url": None,
         "key_env": "CSSWITCH_OPENAI_KEY",
@@ -113,6 +116,23 @@ PROVIDERS = {
         "model_map": {},
         "model_caps": {},
         "default_cap": None,
+        "default_model": "",
+    },
+    "openai-responses": {
+        "mode": "openai",
+        "api_format": "openai_responses",
+        "url": None,
+        "models_url": None,
+        "key_env": "CSSWITCH_OPENAI_KEY",
+        "auth_style": "bearer",
+        "force_model_override": True,
+        "models": [],
+        "model_map": {},
+        "model_caps": {},
+        # DashScope Responses rejects values above 65536; generic Responses-compatible
+        # endpoints commonly accept this as a safe ceiling. Chat Completions custom
+        # intentionally stays unclamped.
+        "default_cap": 65536,
         "default_model": "",
     },
     "relay": {
@@ -145,7 +165,7 @@ AUTH_SECRET = None  # 未设则不启用鉴权（保持旧行为）
 # （如 claude-haiku-4-5-20251001）。首拉前为空 → 纯透传。
 RELAY_MODELS = []
 # 强制模型 override：面板选了模型时，代理无条件把所有请求模型改成它（relay 覆盖透传；
-# openai-custom 覆盖 Science 发来的 claude-* 壳）。由 CSSWITCH_RELAY_MODEL 或
+# openai-custom/openai-responses 覆盖 Science 发来的 claude-* 壳）。由 CSSWITCH_RELAY_MODEL 或
 # CSSWITCH_OPENAI_MODEL 环境变量在 __main__ 里装配；留空 → None。
 RELAY_FORCE_MODEL = None
 # relay thinking 策略（来自模板 thinking_policy）：由 CSSWITCH_RELAY_THINKING 在 __main__ 装配。
@@ -167,7 +187,7 @@ UPSTREAM_UA = "CSSwitch/0.2 (+https://github.com/SuperJJ007/CSSwitch)"
 #   - 403 Forbidden    = 「登录了但没权限」→ operon 当成组织/权限问题【反复重试】→ 一直卡
 #     "Switching organization"（v0.1.4 实机复现：server 日志固定 `/api/oauth/profile → 403`，
 #     无 `treating as logged-out`）。
-# 虚拟登录本就该表现为「未登录」，故用 401。详见 findings/switching-organization-hang.md。
+# 虚拟登录本就该表现为「未登录」，故用 401。
 _BLOCKED_SUFFIXES = ("anthropic.com", "claude.ai", "claude.com")
 
 
@@ -303,7 +323,8 @@ def normalize_openai_base(base):
     """OpenAI 兼容端点存 base root。用户若误填到 /chat/completions 或 /models，
     这里收敛回 root，避免后续双拼。"""
     b = (base or "").strip().rstrip("/")
-    for suffix in ("/v1/chat/completions", "/chat/completions", "/v1/models", "/models"):
+    for suffix in ("/v1/chat/completions", "/chat/completions",
+                   "/v1/responses", "/responses", "/v1/models", "/models"):
         if b.endswith(suffix):
             b = b[: -len(suffix)].rstrip("/")
     return b
@@ -488,6 +509,100 @@ def map_tool_choice(tc, tools):
     return None
 
 
+def map_responses_tool_choice(tc, tools):
+    """把 Anthropic tool_choice 译成 Responses API 取值。
+    千问 Responses 在 thinking mode 下会拒绝 required/object 形态；Science 会在
+    reviewing/agent 路径发送强制工具选择。这里保守降级为 auto，宁可不强制工具，
+    也不要让整个请求 400。"""
+    if not isinstance(tc, dict):
+        return None
+    t = tc.get("type")
+    if t == "auto":
+        return "auto"
+    if t == "none":
+        return "none"
+    if t in ("tool", "any"):
+        return "auto"
+    return None
+
+
+def _as_text(value):
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "".join(x.get("text", "") for x in value if isinstance(x, dict))
+    if value is None:
+        return ""
+    return json.dumps(value, ensure_ascii=False)
+
+
+def anthropic_to_openai_responses(req):
+    sys_prompt = req.get("system")
+    if isinstance(sys_prompt, list):
+        sys_prompt = "\n".join(b.get("text", "") for b in sys_prompt if isinstance(b, dict))
+
+    items = []
+    for m in req.get("messages", []):
+        role = m.get("role")
+        content = m.get("content")
+        if isinstance(content, str):
+            items.append({"role": role, "content": content})
+            continue
+
+        text_parts = []
+        for blk in content or []:
+            t = blk.get("type")
+            if t == "text":
+                text_parts.append(blk.get("text", ""))
+            elif t == "tool_use":
+                if text_parts:
+                    items.append({"role": role, "content": "".join(text_parts)})
+                    text_parts = []
+                items.append({
+                    "type": "function_call",
+                    "call_id": blk.get("id"),
+                    "name": blk.get("name"),
+                    "arguments": json.dumps(blk.get("input", {}), ensure_ascii=False),
+                })
+            elif t == "tool_result":
+                if text_parts:
+                    items.append({"role": role, "content": "".join(text_parts)})
+                    text_parts = []
+                items.append({
+                    "type": "function_call_output",
+                    "call_id": blk.get("tool_use_id"),
+                    "output": _as_text(blk.get("content")),
+                })
+        if text_parts:
+            items.append({"role": role, "content": "".join(text_parts)})
+
+    _st = _provider_state(req)
+    out = {
+        "model": provider_policy.resolve_model(req.get("model"), _st),
+        "input": items,
+        "stream": False,
+    }
+    if sys_prompt:
+        out["instructions"] = sys_prompt
+    if req.get("max_tokens"):
+        out["max_output_tokens"] = provider_policy.clamp_max_tokens(req["max_tokens"], out["model"], _st)
+    if req.get("temperature") is not None:
+        out["temperature"] = req["temperature"]
+    if req.get("top_p") is not None:
+        out["top_p"] = req["top_p"]
+    if req.get("tools"):
+        out["tools"] = [{
+            "type": "function",
+            "name": t["name"],
+            "description": t.get("description", ""),
+            "parameters": t.get("input_schema", {}),
+        } for t in req["tools"] if t.get("name")]
+    tcm = map_responses_tool_choice(req.get("tool_choice"), req.get("tools"))
+    if tcm is not None:
+        out["tool_choice"] = tcm
+    return out
+
+
 def openai_to_anthropic(resp, model_id):
     choice = (resp.get("choices") or [{}])[0]
     msg = choice.get("message", {})
@@ -510,6 +625,53 @@ def openai_to_anthropic(resp, model_id):
         "stop_reason": stop, "stop_sequence": None,
         "usage": {"input_tokens": usage.get("prompt_tokens", 0),
                   "output_tokens": usage.get("completion_tokens", 0)},
+    }
+
+
+def _responses_output_text(item):
+    parts = []
+    for c in item.get("content") or []:
+        if not isinstance(c, dict):
+            continue
+        if c.get("type") in ("output_text", "text"):
+            parts.append(c.get("text", ""))
+    return "".join(parts)
+
+
+def openai_responses_to_anthropic(resp, model_id):
+    blocks = []
+    for item in resp.get("output") or []:
+        if not isinstance(item, dict):
+            continue
+        t = item.get("type")
+        if t == "message":
+            text = _responses_output_text(item)
+            if text:
+                blocks.append({"type": "text", "text": text})
+        elif t == "function_call":
+            raw_args = item.get("arguments") or "{}"
+            try:
+                args = json.loads(raw_args)
+            except Exception:
+                args = {}
+            blocks.append({
+                "type": "tool_use",
+                "id": item.get("call_id") or item.get("id"),
+                "name": item.get("name"),
+                "input": args,
+            })
+    if not blocks and resp.get("output_text"):
+        blocks.append({"type": "text", "text": resp.get("output_text", "")})
+    usage = resp.get("usage", {})
+    stop = "tool_use" if any(b.get("type") == "tool_use" for b in blocks) else "end_turn"
+    if resp.get("status") == "incomplete":
+        stop = "max_tokens"
+    return {
+        "id": resp.get("id", "msg_proxy"), "type": "message", "role": "assistant", "model": model_id,
+        "content": blocks or [{"type": "text", "text": ""}],
+        "stop_reason": stop, "stop_sequence": None,
+        "usage": {"input_tokens": usage.get("input_tokens", 0),
+                  "output_tokens": usage.get("output_tokens", 0)},
     }
 
 
@@ -798,16 +960,24 @@ class H(BaseHTTPRequestHandler):
     def _handle_openai(self, areq):
         model_id = areq.get("model", "claude-sonnet-5")
         stream = bool(areq.get("stream"))
-        oreq = anthropic_to_openai(areq)
+        if PROV.get("api_format") == "openai_responses":
+            oreq = anthropic_to_openai_responses(areq)
+            msg_count = len(oreq.get("input") or [])
+        else:
+            oreq = anthropic_to_openai(areq)
+            msg_count = len(oreq.get("messages") or [])
         n_tools = len(oreq.get("tools", []))
         log(f"POST /v1/messages  {model_id}->{oreq['model']} stream={stream} tools={n_tools} "
-            f"msgs={len(oreq['messages'])}  (入站鉴权已剥离, {PROV_NAME})")
+            f"msgs={msg_count}  (入站鉴权已剥离, {PROV_NAME})")
         headers = {"Authorization": f"Bearer {KEY}", "Content-Type": "application/json"}
         data = json.dumps(oreq).encode()
         try:
             raw, _ct = http_post(PROV["url"], data, headers)
             oresp = json.loads(raw)
-            aresp = openai_to_anthropic(oresp, model_id)
+            if PROV.get("api_format") == "openai_responses":
+                aresp = openai_responses_to_anthropic(oresp, model_id)
+            else:
+                aresp = openai_to_anthropic(oresp, model_id)
             if stream:
                 self._replay_as_sse(aresp)
             else:
@@ -890,15 +1060,16 @@ if __name__ == "__main__":
         if forced:
             RELAY_FORCE_MODEL = forced
         RELAY_THINKING = (os.environ.get("CSSWITCH_RELAY_THINKING") or "").strip() or None
-    elif PROV_NAME == "openai-custom":
+    elif PROV_NAME in ("openai-custom", "openai-responses"):
         base = normalize_openai_base(os.environ.get("CSSWITCH_OPENAI_BASE_URL") or args.openai_base or "")
         if not base or not re.match(r"^https?://", base):
-            print("openai-custom 需要 OpenAI base root（http(s)://…）。用 --openai-base 或环境变量 "
+            print(f"{PROV_NAME} 需要 OpenAI base root（http(s)://…）。用 --openai-base 或环境变量 "
                   "CSSWITCH_OPENAI_BASE_URL 提供。", file=sys.stderr)
             sys.exit(1)
         forced = (os.environ.get("CSSWITCH_OPENAI_MODEL") or "").strip()
         PROV = dict(PROV)
-        PROV["url"] = openai_endpoint(base, "/chat/completions")
+        suffix = "/responses" if PROV.get("api_format") == "openai_responses" else "/chat/completions"
+        PROV["url"] = openai_endpoint(base, suffix)
         PROV["models_url"] = openai_endpoint(base, "/models")
         # 模型发现 scratch 只需要 /models，不能要求 CSSWITCH_OPENAI_MODEL；
         # 正式推理由 Rust 侧 relay_missing_model + Message 探针保证 model 必填。

--- a/test/mock_upstream.py
+++ b/test/mock_upstream.py
@@ -1,6 +1,7 @@
 """测试用假上游：记账命中次数，按 mode 返回不同响应。
 mode="json"：返回一份最小 Anthropic 非流式消息体。
-mode="status:NNN"：返回 HTTP NNN + 一小段错误 JSON（测代理对上游错误码的处理，如 P3 401/403 透传）。"""
+mode="status:NNN"：返回 HTTP NNN + 一小段错误 JSON（测代理对上游错误码的处理，如 P3 401/403 透传）。
+mode="openai_responses"：返回一份最小 OpenAI Responses 响应体。"""
 import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -15,9 +16,32 @@ def start_mock(mode="json"):
 
         def do_POST(self):
             n = int(self.headers.get("Content-Length") or 0)
-            self.rfile.read(n)
+            raw = self.rfile.read(n)
             hits.append(self.path)
-            if mode == "json":
+            if mode == "openai_responses":
+                try:
+                    req = json.loads(raw or b"{}")
+                except Exception:
+                    req = {}
+                body = json.dumps({
+                    "id": "resp_mock",
+                    "object": "response",
+                    "status": "completed",
+                    "model": req.get("model", "mock"),
+                    "output": [{
+                        "id": "msg_mock",
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "ok-responses"}],
+                    }],
+                    "usage": {"input_tokens": 2, "output_tokens": 3},
+                }).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            elif mode == "json":
                 body = json.dumps({
                     "id": "msg_mock", "type": "message", "role": "assistant",
                     "model": "mock", "content": [{"type": "text", "text": "ok"}],

--- a/test/test_proxy_auth.py
+++ b/test/test_proxy_auth.py
@@ -287,5 +287,48 @@ class ProxyOpenAICustomModelsDiscovery(unittest.TestCase):
         self.assertEqual(self.hits, ["/up/v1/models"])
 
 
+@unittest.skipUnless(loopback_available(), "env-blocked: loopback bind/connect not permitted")
+class ProxyOpenAIResponses(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.up_url, cls.hits, cls.stop_up = start_mock("openai_responses")
+        port = 18996
+        cls.base = f"http://127.0.0.1:{port}"
+        cls.logf = os.path.join(tempfile.gettempdir(), f"csswitch-openai-responses-{port}.log")
+        open(cls.logf, "w").close()
+        env = dict(os.environ, CSSWITCH_OPENAI_KEY="fake-openai-key",
+                   CSSWITCH_OPENAI_BASE_URL=cls.up_url,
+                   CSSWITCH_OPENAI_MODEL="gpt-5.2")
+        cls.proc = subprocess.Popen(
+            [sys.executable, PROXY, "--provider", "openai-responses",
+             "--port", str(port), "--auth-token", SEC, "--log", cls.logf],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        for _ in range(50):
+            try:
+                s, _b = _req(f"{cls.base}/{SEC}/health")
+                if s == 200:
+                    break
+            except Exception:
+                pass
+            time.sleep(0.1)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.wait(timeout=5)
+        cls.stop_up()
+
+    def test_messages_use_responses_endpoint_and_convert_back(self):
+        s, b = _req(f"{self.base}/{SEC}/v1/messages", "POST",
+                    {"model": "claude-opus-4-8", "max_tokens": 10,
+                     "messages": [{"role": "user", "content": "hi"}]})
+        self.assertEqual(s, 200, b[:160])
+        body = json.loads(b)
+        self.assertEqual(body["content"], [{"type": "text", "text": "ok-responses"}])
+        self.assertEqual(body["usage"], {"input_tokens": 2, "output_tokens": 3})
+        self.assertIn("/up/v1/responses", self.hits)
+        self.assertNotIn("/up/v1/chat/completions", self.hits)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_proxy_units.py
+++ b/test/test_proxy_units.py
@@ -78,6 +78,30 @@ class ResponsesMapping(unittest.TestCase):
         self.assertEqual(out["tools"][0]["name"], "lookup")
         self.assertEqual(out["tool_choice"], "auto")
 
+    def test_responses_forced_tool_choice_string_degrades_to_auto(self):
+        out = cs.anthropic_to_openai_responses({
+            "model": "claude-opus-4-8",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"name": "lookup", "input_schema": {"type": "object"}}],
+            "tool_choice": "required",
+        })
+        self.assertEqual(out["tool_choice"], "auto")
+
+    def test_dashscope_responses_tool_requests_use_conservative_cap(self):
+        old_url = cs.PROV.get("url")
+        cs.PROV["url"] = "https://dashscope.aliyuncs.com/compatible-mode/v1/responses"
+        try:
+            out = cs.anthropic_to_openai_responses({
+                "model": "claude-opus-4-8",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 999999,
+                "tools": [{"name": "lookup", "input_schema": {"type": "object"}}],
+            })
+        finally:
+            cs.PROV["url"] = old_url
+        self.assertEqual(out["max_output_tokens"], 8192)
+        self.assertEqual(out["tool_choice"], "auto")
+
     def test_responses_tool_choice_none_passthrough(self):
         out = cs.anthropic_to_openai_responses({
             "model": "claude-opus-4-8",

--- a/test/test_proxy_units.py
+++ b/test/test_proxy_units.py
@@ -102,6 +102,31 @@ class ResponsesMapping(unittest.TestCase):
         self.assertEqual(out["max_output_tokens"], 8192)
         self.assertEqual(out["tool_choice"], "auto")
 
+    def test_dashscope_responses_drops_incompatible_web_search_tool(self):
+        old_url = cs.PROV.get("url")
+        cs.PROV["url"] = "https://dashscope.aliyuncs.com/compatible-mode/v1/responses"
+        try:
+            out = cs.anthropic_to_openai_responses({
+                "model": "claude-opus-4-8",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": [
+                    {"name": "web_search", "input_schema": {"type": "object"}},
+                    {"name": "lookup", "input_schema": {"properties": {"q": {"type": "string"}}}},
+                ],
+            })
+        finally:
+            cs.PROV["url"] = old_url
+        self.assertEqual([t["name"] for t in out["tools"]], ["lookup"])
+        self.assertEqual(out["tools"][0]["parameters"]["type"], "object")
+
+    def test_non_dashscope_responses_keeps_web_search_tool(self):
+        out = cs.anthropic_to_openai_responses({
+            "model": "claude-opus-4-8",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"name": "web_search", "input_schema": {"type": "object"}}],
+        })
+        self.assertEqual(out["tools"][0]["name"], "web_search")
+
     def test_responses_tool_choice_none_passthrough(self):
         out = cs.anthropic_to_openai_responses({
             "model": "claude-opus-4-8",

--- a/test/test_proxy_units.py
+++ b/test/test_proxy_units.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "proxy"))
@@ -42,6 +43,84 @@ class ToolChoiceMapping(unittest.TestCase):
         self.assertEqual(out["tool_choice"], {"type": "function", "function": {"name": "grade"}})
         self.assertEqual(out["stop"], ["STOP"])
         self.assertEqual(out["top_p"], 0.5)
+
+
+class ResponsesMapping(unittest.TestCase):
+    def setUp(self):
+        cs.PROV = dict(cs.PROVIDERS["openai-responses"])
+        cs.PROV_NAME = "openai-responses"
+        cs.PROV["default_model"] = "gpt-5.2"
+        cs.KEY = "sk-openai"
+        cs.RELAY_FORCE_MODEL = "gpt-5.2"
+
+    def tearDown(self):
+        cs.RELAY_FORCE_MODEL = None
+
+    def test_responses_request_maps_prompt_tools_and_limits(self):
+        req = {
+            "model": "claude-opus-4-8",
+            "system": [{"type": "text", "text": "be brief"}],
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 999999,
+            "temperature": 0.2,
+            "top_p": 0.9,
+            "tools": [{"name": "lookup", "description": "search", "input_schema": {"type": "object"}}],
+            "tool_choice": {"type": "tool", "name": "lookup"},
+        }
+        out = cs.anthropic_to_openai_responses(req)
+        self.assertEqual(out["model"], "gpt-5.2")
+        self.assertEqual(out["instructions"], "be brief")
+        self.assertEqual(out["input"], [{"role": "user", "content": "hi"}])
+        self.assertEqual(out["max_output_tokens"], 65536)
+        self.assertEqual(out["temperature"], 0.2)
+        self.assertEqual(out["top_p"], 0.9)
+        self.assertEqual(out["tools"][0]["type"], "function")
+        self.assertEqual(out["tools"][0]["name"], "lookup")
+        self.assertEqual(out["tool_choice"], "auto")
+
+    def test_responses_tool_choice_none_passthrough(self):
+        out = cs.anthropic_to_openai_responses({
+            "model": "claude-opus-4-8",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": {"type": "none"},
+        })
+        self.assertEqual(out["tool_choice"], "none")
+
+    def test_responses_request_maps_tool_results(self):
+        req = {
+            "model": "claude-opus-4-8",
+            "messages": [
+                {"role": "assistant", "content": [
+                    {"type": "text", "text": "checking"},
+                    {"type": "tool_use", "id": "call_1", "name": "lookup", "input": {"q": "x"}},
+                ]},
+                {"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "call_1", "content": [{"type": "text", "text": "found"}]},
+                ]},
+            ],
+        }
+        out = cs.anthropic_to_openai_responses(req)
+        self.assertEqual(out["input"][0], {"role": "assistant", "content": "checking"})
+        self.assertEqual(out["input"][1]["type"], "function_call")
+        self.assertEqual(out["input"][1]["call_id"], "call_1")
+        self.assertEqual(json.loads(out["input"][1]["arguments"]), {"q": "x"})
+        self.assertEqual(out["input"][2], {"type": "function_call_output", "call_id": "call_1", "output": "found"})
+
+    def test_responses_response_maps_text_and_function_call(self):
+        resp = {
+            "id": "resp_1",
+            "status": "completed",
+            "output": [
+                {"type": "message", "content": [{"type": "output_text", "text": "hello"}]},
+                {"type": "function_call", "call_id": "call_2", "name": "lookup", "arguments": "{\"q\":\"y\"}"},
+            ],
+            "usage": {"input_tokens": 4, "output_tokens": 5},
+        }
+        out = cs.openai_responses_to_anthropic(resp, "claude-opus-4-8")
+        self.assertEqual(out["content"][0], {"type": "text", "text": "hello"})
+        self.assertEqual(out["content"][1], {"type": "tool_use", "id": "call_2", "name": "lookup", "input": {"q": "y"}})
+        self.assertEqual(out["stop_reason"], "tool_use")
+        self.assertEqual(out["usage"], {"input_tokens": 4, "output_tokens": 5})
 
 
 class RelayProvider(unittest.TestCase):
@@ -162,11 +241,16 @@ class OpenAICustomProvider(unittest.TestCase):
     def test_openai_base_root_normalization(self):
         root = "https://open.bigmodel.cn/api/paas/v4"
         self.assertEqual(cs.normalize_openai_base(root + "/chat/completions"), root)
+        self.assertEqual(cs.normalize_openai_base(root + "/responses"), root)
         self.assertEqual(cs.normalize_openai_base(root + "/models"), root)
         self.assertEqual(cs.openai_endpoint(root + "/chat/completions", "/models"), root + "/models")
         self.assertEqual(
             cs.openai_endpoint(root + "/models", "/chat/completions"),
             root + "/chat/completions",
+        )
+        self.assertEqual(
+            cs.openai_endpoint(root + "/responses", "/responses"),
+            root + "/responses",
         )
         self.assertEqual(
             cs.openai_endpoint("https://api.siliconflow.cn", "/chat/completions"),


### PR DESCRIPTION
## Summary

Adds a custom OpenAI Responses provider path alongside the existing Anthropic-compatible and OpenAI Chat-compatible adapters.

- Adds the `custom-openai-responses` template and `openai-responses` adapter wiring.
- Derives `/responses` and `/models` from the configured OpenAI-compatible base root.
- Converts basic Anthropic Messages requests and responses to/from OpenAI Responses.
- Applies a conservative `max_output_tokens` cap and degrades forced tool choices to `auto` for stricter Responses-compatible endpoints.
- Documents the current provider capability boundary and the Responses streaming limitation.

## Current boundary

The Responses path currently sends a non-streaming upstream request and replays the final Anthropic response as local SSE when the downstream caller asks for streaming. This is intentionally documented as a compatibility slice, not full native Responses SSE conversion.

## Validation

- `test/run_all.sh`
- Result: `release-ready green: YES` with offline, loopback, scripts, rust, and frontend layers all passing.
