### PR TITLE
fix: normalize relay tool schemas

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -27,6 +27,15 @@
 - **待收集（下次复现时）**：① 完整报错文本；② 它请求的**具体路径**是什么；③ 是否只有 DeepSeek 触发、还是任何 provider 都这样；④ 该自检具体是什么（Science 自带的环境自检？哪个 agent 发起？）。
 - **不改代码**，先记录待查。
 
+## 2a. Claude Science `0.1.15-dev` native 基线漂移（需隔离复核）
+
+> **状态：只读基线已更新，未做真实账号态 / 真实 HOME / GUI E2E。**
+
+- **当前本机安装版**：`/Applications/Claude Science.app` 仍是 `0.1.0-dev.20260630.t212931.sha2bc1ac8`。
+- **本地缓存证据版**：`.science-binaries/README.md` 记录过 `0.1.15-dev.20260701.t220242.shaaa553de`；该缓存只作为本地证据，不随公开包发布。本轮未读取、未复制、未修改真实 `~/.claude-science`。
+- **route diff 新增面**：`/api/auth/nonce`、`/api/auth/` 可能影响虚拟 OAuth / auth status；`/api/conda/conda-remote`、`/api/pypi/pypi-remote/simple`、conda mirror preference/probe 可能影响沙箱包源代理；`/api/frames/:id/token-series`、`/api/skills/:name/resync` 可能影响诊断或技能同步行为。
+- **下一步**：在 `0.1.15-dev` 二进制可控时，用隔离 HOME + 非 `8765` 端口复跑虚拟 OAuth、沙箱启动、包源代理相关最小路径；不要从当前 `0.1.0-dev` 实测外推兼容结论。
+
 ## 3. ✅ 运行中再点主按钮的幂等分派（已随 v0.2.0 发布，已毕业）
 
 > **状态：已随 v0.2.0（2026-07-03，Latest）发布并毕业到 [`../CHANGELOG.md`](../CHANGELOG.md) 的 `[0.2.0]`。** 幂等 forge 落地（org_uuid 只在真首启铸一次、此后 sticky，健康沙箱只重开不重伪造），实机 T1 已验证「会话不会丢」；同时阻止 #6 复发。详细设计与实现计划见本地开发文档（不入库）。原设计如下（历史留存）：
@@ -103,7 +112,7 @@
 
 - **要做什么（用户 2026-07-03）**：像 cc-switch 那样能**存多套命名配置（profile）**、列出来、一键切当前生效的那套（同一家可存多套、可命名、可增删）。现在是**固定槽**（deepseek/qwen/relay-glm/…每家一份），做不到多套 → 数据模型从「固定槽」升级为「用户自管的 profile 列表 + 当前生效指针」。
 - **配置存储：先不换 SQLite（用户要「保持稳定」）。** 多 profile 只是数据模型（JSON 存一个数组即可），跟存储后端解耦。这版继续 JSON、把它硬化（原子写已有 + schema 版本字段 + 覆盖前留 `.bak` + 修面板回显可见性缺口）；SQLite 留到确有扩展需求（多窗口并发 / 大量记录 / 历史）时再迁，届时 JSON→SQLite 迁移很简单。SQLite 价值在可扩展+并发，不在「更稳」。
-- **代理移 Rust（独立轨道）**：翻译代理从 python 移到 Rust（axum），**vendor cc-switch 的 MIT `transform*.rs`** 拿广覆盖（4 种 apiFormat），加我们的 path-secret + 虚拟 OAuth 剥离。cc-switch 代理**不能当 sidecar 直接复用**（焊死它的 SQLite DB，见 `verified-facts.md` 事实 5），复用 = 移植它的翻译模块。这条同时完成 python-ectomy 治本，与「多 profile 配置」解耦。
+- **代理移 Rust（独立轨道）**：翻译代理从 python 移到 Rust（axum），**vendor cc-switch 的 MIT `transform*.rs`** 拿广覆盖（4 种 apiFormat），加我们的 path-secret + 虚拟 OAuth 剥离。cc-switch 代理**不能当 sidecar 直接复用**（焊死它的 SQLite DB，见 `verified-facts.md` 事实 6），复用 = 移植它的翻译模块。这条同时完成 python-ectomy 治本，与「多 profile 配置」解耦。
 - **relay-presets 分支现状**：`feat/relay-presets`（Task1-13 全实现 + opus 终审过）实现了 relay provider + 预设 + 面板选模型，但用**固定槽 + python 代理**，**降为参考/回退，不作为发布基座**（重架后被多 profile + Rust 代理取代）。HEAD `2a5084f`（f148eb2 + P3 hygiene 修）**clippy-green**。GPT 外审逐条核实：P1「保存写错槽+覆盖」= 尖端已修（STALE）；P1b「保存非原子」+ P2a「自愈忽略停沙箱失败 `lib.rs:967`」= 真 Important、折进重架设计（P2a 应像 `set_mode` 停失败即中止）；P2b「python 代理 OSError 全当占用」= 真但代理要换掉；P3「clippy 2 处 + 版本不一致」= 已修（`2a5084f`）。**教训**：验收闸门要含 `cargo clippy --all-targets -D warnings`（比 `cargo test` 的 rustc 警告更严；账本旧称「0 warnings」漏了 clippy）。
 - **隔离层四家实测证据**：`findings/2026-07-03-pr4-relay-provider-testing.md`（GLM/小米/硅基流动/OpenRouter 真机实测，含工具，守铁律4 未启 Science），已随 `c8b9cfe` 提交。
 - **下一步**：① **用户在场做真机整链手测**（构建 + 启动 app，逐项过：迁移后旧对话在不在 / 新建 / 切换 / 一键开始 / 连接编辑 / 清 key / 删除；起沙箱 Science + 登录那步由用户手动，守铁律 2/3/4）；② 过了再谈 merge（现未 push、main 未动）+ 更新 `CHANGELOG.md`（**故意还没写**，避免仓库里提前显「已完成」）；③ 轨道 2 = 代理移 Rust（另起 spec）。spec/计划在 `docs/superpowers/`（gitignore）。
@@ -115,7 +124,7 @@
 - **② 「API 支持」重架（已升级为 #8，2026-07-03）**：原「面板内自定义 OpenAI 端点」升级为 cc-switch 式**多 profile 配置管理**（存多套命名配置 + 一键切）+ 代理移 Rust（vendor cc-switch MIT 翻译模块）。配置层先 JSON 硬化、SQLite 缓议。详见 **#8**。
 
 **其它 roadmap（非 bug）**：
-- **python-ectomy**：翻译代理移到 Rust（axum），拔掉 python（node 已在 v0.1.4 拔除），最终零外部运行时。**落地方式（2026-07-03 定）= vendor cc-switch 的 MIT `transform*.rs` 拿广覆盖**（见 #8、`verified-facts.md` 事实 5）。
+- **python-ectomy**：翻译代理移到 Rust（axum），拔掉 python（node 已在 v0.1.4 拔除），最终零外部运行时。**落地方式（2026-07-03 定）= vendor cc-switch 的 MIT `transform*.rs` 拿广覆盖**（见 #8、`verified-facts.md` 事实 6）。
 - Intel（x86_64）/ universal 构建；可选正式签名 + Apple 公证。
 
 ---

--- a/docs/verified-facts.md
+++ b/docs/verified-facts.md
@@ -16,17 +16,22 @@
    - Science 自身 `GET /api/auth/status` 返回 `authenticated:true, email:virtual@localhost.invalid`。
    - 沙箱守护 API：身份取自磁盘令牌；写操作需 `Origin: http://localhost:<port>` + 双提交 CSRF（cookie `operon_csrf` 回显头 `x-operon-csrf`）；建会话 `POST /api/frames {project_id}`，发消息 `POST /api/frames/:id/message {input_data:{request:"..."}, model}`（**用户文本键是 `request`，不是 text**）。
    - **沙箱钥匙串弹窗（已修 2026-07-02）**：Science 会把 `encryption.key` 镜像进 macOS 钥匙串；沙箱独立 HOME 下无钥匙串 → securityd 反复弹「找不到钥匙串」。修法：`launch-virtual-sandbox.sh` 在沙箱 HOME 内建一个独立、空密码、不自动锁的 `login.keychain-db`，只在 `HOME=$SANDBOX_HOME` 上下文里操作。核对前后**真实** `~/Library/Keychains` 逐字节不变。
+4. **Claude Science native 基线有版本漂移（2026-07-08 只读复核）**：
+   - 本机 `/Applications/Claude Science.app` 的 `Info.plist` 与 `claude-science --version` 均为 `0.1.0-dev.20260630.t212931.sha2bc1ac8 (release, public)`。
+   - 仓库本地缓存证据 `.science-binaries/README.md` 记录过 `0.1.15-dev.20260701.t220242.shaaa553de`，但该目录为本地证据缓存、未入公开包；本次未读取、未复制、未修改真实 `~/.claude-science`。
+   - 已有 route diff 记录 `0.1.15-dev` 相比 `0.1.0-dev` 新增 `/api/auth/nonce`、`/api/auth/`、`/api/conda/conda-remote`、`/api/credentials/openalex/validate`、`/api/frames/:id/token-series`、`/api/preferences/conda-mirror`、`/api/preferences/conda-mirror/probe`、`/api/pypi/pypi-remote/simple`、`/api/skills/:name/resync`，未见删除路由。
+   - 公开 Anthropic 发布页只确认 Claude Science beta 可用于 macOS/Linux，未公开版本号或 changelog；版本判断仍以本机 plist/二进制与本地缓存证据为准。
 
 ## 二、代理与整链
 
-4. **翻译代理 ↔ 真实通义千问整条链路已跑通**（`proxy/qwen_proxy.py`，隔离环境，未碰 Science/OAuth/CC Switch）：`/v1/models`、非流式、流式 SSE、tool_use 发起、tool_result 回喂后接着作答全部通过；入站 OAuth Bearer 逐条确认被剥离。证据 `findings/e2e-proxy-qwen-proof.log`。
-5. **CC Switch 的代理是完整翻译器，但不能当独立 sidecar 复用**（2026-07-03 读 v3.16.5 源码复核，farion1231/cc-switch，**MIT**）：
+5. **翻译代理 ↔ 真实通义千问整条链路已跑通**（`proxy/qwen_proxy.py`，隔离环境，未碰 Science/OAuth/CC Switch）：`/v1/models`、非流式、流式 SSE、tool_use 发起、tool_result 回喂后接着作答全部通过；入站 OAuth Bearer 逐条确认被剥离。证据 `findings/e2e-proxy-qwen-proof.log`。
+6. **CC Switch 的代理是完整翻译器，但不能当独立 sidecar 复用**（2026-07-03 读 v3.16.5 源码复核，farion1231/cc-switch，**MIT**）：
    - 早期二进制观察（留存）：含 `/v1/messages`、`/v1/chat/completions`、`cc_switch_transform_error`、两套协议字段与 SSE 桥接，内建模型目录含 DeepSeek/Qwen/Kimi；端口默认 `127.0.0.1:15721`。
    - **无 headless / CLI / 独立二进制**：代理只在它 Tauri GUI 进程内跑，构造即绑死它的 SQLite `Database`（`ProxyServer::new(config, Arc<Database>, Option<tauri::AppHandle>)`），每个请求都查该 DB 选 provider。**没有可 spawn 的 sidecar**，`ANTHROPIC_BASE_URL` 无处可指，除非把它整个 app 一起打包。
    - **翻译契合度极高**：`forwarder.rs` 对入站 `authorization/x-api-key/x-goog-api-key` 一律丢弃、换成 adapter 提供的上游鉴权头（`AuthStrategy`：Anthropic→x-api-key / Bearer / Google→x-goog-api-key / OAuth），正是我们「丢弃 Science 虚拟 OAuth、注入第三方 key」所需；`providers/transform*.rs` 双向 Anthropic↔OpenAI/Responses/Gemini，含 SSE + tool_use/tool_result。
    - **两个缺口**：① 入站**无鉴权**（无 path-secret，仅靠 bind localhost）→ 复用要自己加门；② 配置**存 SQLite、非配置文件**（provider 行 + `apiFormat` 字段 `anthropic|openai_chat|openai_responses|gemini_native`，由 GUI/IPC 灌），不是我们能直接写的文件。
    - **结论**：复用 = 把它的 MIT `transform*.rs` 等翻译模块**移植/vendor 进我们自己的（Rust）代理**当参考实现，不是插它的二进制。license MIT（署名即可），但仓库周更（v3.16.5、~2050 commits），fork 有持续跟进成本。证据：本会话 general-purpose 研究 agent（引用 `src-tauri/src/proxy/*`）。
-6. **DeepSeek 接入（默认上游，2026-07-02）**：主代理 `proxy/csswitch_proxy.py`，provider 可切（`--provider deepseek|qwen`）。
+7. **DeepSeek 接入（默认上游，2026-07-02）**：主代理 `proxy/csswitch_proxy.py`，provider 可切（`--provider deepseek|qwen`）。
    - DeepSeek 走**原生 Anthropic 端点** `https://api.deepseek.com/anthropic/v1/messages`，鉴权头 `x-api-key`，代理只「改模型名 + 换鉴权 + 归一化 thinking + 夹 max_tokens + 重试」，**不翻译协议** → thinking/tool_use 原生保真。
    - 模型：`claude-opus-4-8→deepseek-v4-pro`、`claude-haiku/sonnet→deepseek-v4-flash`。
    - **模型选择器主列表机制（逆向 `s0`/`ZjO`/`XjO`/`hB_`）**：① `s0`：id 必须以 `claude-` 开头否则不显示。② 只有 `ZjO(id)<3`（opus=0/sonnet=1/haiku=2/其它=3）且 `XjO(id)` 命中 `^claude-(opus|sonnet|haiku)-<纯数字版本>$` 的 id 才进【主列表】，每 family 一个；其余折叠进「More models」。所以要让第三方模型平铺，就挂在 `claude-opus-4-8`/`claude-haiku-4-5` 这类主列表 id 上、显示名照写第三方。
@@ -47,5 +52,5 @@
 ## 四、其它
 
 - Qwen(DashScope) 为 OpenAI-兼容备选（`--provider qwen`，翻译路径）；`proxy/qwen_proxy.py` 是其早期单 provider 版，已被 `csswitch_proxy.py` 取代。
-- **已决（2026-07-03）**：CC Switch 代理不能当 sidecar 直接复用（见事实 5）。方向 = 自研代理移 Rust（axum）+ vendor CC Switch 的 MIT 翻译模块拿广覆盖（治本 python-ectomy）。这条独立于「配置层多 profile 化」，各走节奏。见 `known-issues.md` #8。
+- **已决（2026-07-03）**：CC Switch 代理不能当 sidecar 直接复用（见事实 6）。方向 = 自研代理移 Rust（axum）+ vendor CC Switch 的 MIT 翻译模块拿广覆盖（治本 python-ectomy）。这条独立于「配置层多 profile 化」，各走节奏。见 `known-issues.md` #8。
 - DashScope 兼容端点：`https://dashscope.aliyuncs.com/compatible-mode/v1`。DashScope 偶发连接抖动（SSL EOF `_ssl.c:1129`/握手超时），代理已加连接级重试（4 次退避，仅重试连接错误）。

--- a/proxy/anthropic_compat.py
+++ b/proxy/anthropic_compat.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 import dsml_shim
 import provider_policy
 
+_EMPTY_OBJECT_SCHEMA = {"type": "object", "properties": {}}
+
 
 @dataclass
 class Ctx:
@@ -21,6 +23,64 @@ class Ctx:
     provider: str
 
 
+def _normalize_relay_input_schema(schema):
+    if not isinstance(schema, dict) or not schema:
+        return dict(_EMPTY_OBJECT_SCHEMA)
+
+    out = dict(schema)
+    props = out.get("properties")
+    typ = out.get("type")
+
+    if typ is None and isinstance(props, dict):
+        out["type"] = "object"
+    elif typ != "object":
+        out = dict(_EMPTY_OBJECT_SCHEMA)
+        props = out["properties"]
+
+    if not isinstance(out.get("properties"), dict):
+        out["properties"] = {}
+    if "required" in out and not isinstance(out["required"], list):
+        out.pop("required", None)
+    return out
+
+
+def _degrade_missing_tool_choice(upstream):
+    choice = upstream.get("tool_choice")
+    if not (isinstance(choice, dict) and choice.get("type") == "tool"):
+        return
+    names = {t.get("name") for t in upstream.get("tools") or [] if isinstance(t, dict)}
+    if choice.get("name") not in names:
+        upstream["tool_choice"] = {"type": "auto"}
+
+
+def _normalize_relay_tools(upstream):
+    """Normalize Anthropic-compatible relay tool schemas before outbound.
+
+    Some Anthropic-compatible relay providers reject Claude Science's empty or loose
+    ``input_schema`` values with a provider-side 400. Keep this limited to relay
+    passthrough; OpenAI/Qwen/Responses conversions have their own mapping rules.
+    """
+    tools = upstream.get("tools")
+    if not isinstance(tools, list):
+        if "tools" in upstream:
+            upstream.pop("tools", None)
+            _degrade_missing_tool_choice(upstream)
+        return
+
+    normalized = []
+    for tool in tools:
+        if not isinstance(tool, dict) or not tool.get("name"):
+            continue
+        clean = dict(tool)
+        clean["input_schema"] = _normalize_relay_input_schema(tool.get("input_schema"))
+        normalized.append(clean)
+    if normalized:
+        upstream["tools"] = normalized
+    else:
+        upstream.pop("tools", None)
+    _degrade_missing_tool_choice(upstream)
+
+
 def _filter_upstream_tools(upstream, target_model, provider):
     """Provider-specific tool compatibility before sending to upstream.
 
@@ -29,7 +89,10 @@ def _filter_upstream_tools(upstream, target_model, provider):
     expects ordinary client tools, so those server-tool blocks make the stream
     retry. Keep the original known_tools in ctx, but do not advertise this one tool upstream.
     """
-    if provider == "relay" and "kimi" in (target_model or "").lower():
+    if provider != "relay":
+        return
+    _normalize_relay_tools(upstream)
+    if "kimi" in (target_model or "").lower():
         tools = upstream.get("tools")
         if isinstance(tools, list):
             filtered = [t for t in tools if not (isinstance(t, dict) and t.get("name") == "web_search")]
@@ -38,6 +101,7 @@ def _filter_upstream_tools(upstream, target_model, provider):
                     upstream["tools"] = filtered
                 else:
                     upstream.pop("tools", None)
+                _degrade_missing_tool_choice(upstream)
 
 
 def transform_request(body, state):

--- a/test/test_anthropic_compat.py
+++ b/test/test_anthropic_compat.py
@@ -101,6 +101,60 @@ class TransformRequest(unittest.TestCase):
         up, _ctx = ac.transform_request(body, st)
         self.assertEqual([t["name"] for t in up["tools"]], ["web_search"])
 
+    def test_relay_normalizes_loose_tool_schemas(self):
+        st = _state(dict(cs.PROVIDERS["relay"]), "relay",
+                    relay_force_model="MiniMax-M2")
+        body = {"model": "claude-opus-4-8", "messages": [],
+                "tools": [
+                    {"name": "empty", "input_schema": {}},
+                    {"name": "props_only", "input_schema": {
+                        "properties": {"q": {"type": "string"}},
+                    }},
+                    {"name": "bad_props", "input_schema": {
+                        "type": "object", "properties": [], "required": "q",
+                    }},
+                    {"name": "not_dict", "input_schema": []},
+                    {"name": "", "input_schema": {"type": "object"}},
+                    "bad-tool",
+                ]}
+        up, ctx = ac.transform_request(body, st)
+        schemas = {t["name"]: t["input_schema"] for t in up["tools"]}
+        self.assertEqual(list(schemas), ["empty", "props_only", "bad_props", "not_dict"])
+        self.assertEqual(schemas["empty"], {"type": "object", "properties": {}})
+        self.assertEqual(schemas["props_only"]["type"], "object")
+        self.assertEqual(schemas["props_only"]["properties"]["q"]["type"], "string")
+        self.assertEqual(schemas["bad_props"], {"type": "object", "properties": {}})
+        self.assertEqual(schemas["not_dict"], {"type": "object", "properties": {}})
+        self.assertEqual(set(ctx.known_tools), {"empty", "props_only", "bad_props", "not_dict"})
+        self.assertEqual(body["tools"][0]["input_schema"], {}, "不应原地改调用者请求体")
+
+    def test_relay_tool_choice_for_removed_tool_degrades_to_auto(self):
+        st = _state(dict(cs.PROVIDERS["relay"]), "relay",
+                    relay_force_model="MiniMax-M2")
+        body = {"model": "claude-opus-4-8", "messages": [],
+                "tool_choice": {"type": "tool", "name": "removed"},
+                "tools": [{"name": "", "input_schema": {"type": "object"}}]}
+        up, _ctx = ac.transform_request(body, st)
+        self.assertNotIn("tools", up)
+        self.assertEqual(up["tool_choice"], {"type": "auto"})
+
+    def test_kimi_web_search_tool_choice_degrades_to_auto_after_filter(self):
+        st = _state(dict(cs.PROVIDERS["relay"]), "relay",
+                    relay_force_model="kimi-k2.7-code")
+        body = {"model": "claude-opus-4-8", "messages": [],
+                "tool_choice": {"type": "tool", "name": "web_search"},
+                "tools": [{"name": "web_search", "input_schema": {"type": "object"}}]}
+        up, _ctx = ac.transform_request(body, st)
+        self.assertNotIn("tools", up)
+        self.assertEqual(up["tool_choice"], {"type": "auto"})
+
+    def test_non_relay_tool_schemas_are_not_normalized_here(self):
+        st = _state(cs.PROVIDERS["deepseek"], "deepseek")
+        body = {"model": "claude-opus-4-8", "messages": [],
+                "tools": [{"name": "loose", "input_schema": {}}]}
+        up, _ctx = ac.transform_request(body, st)
+        self.assertEqual(up["tools"][0]["input_schema"], {})
+
     def test_no_max_tokens_left_absent(self):
         st = _state(cs.PROVIDERS["deepseek"], "deepseek")
         up, _ctx = ac.transform_request({"model": "claude-opus-4-8", "messages": []}, st)

--- a/test/test_proxy_auth.py
+++ b/test/test_proxy_auth.py
@@ -8,6 +8,7 @@ import time
 import unittest
 import urllib.error
 import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 HERE = os.path.dirname(__file__)
 sys.path.insert(0, HERE)
@@ -16,6 +17,43 @@ from _capability import loopback_available
 
 PROXY = os.path.join(HERE, "..", "proxy", "csswitch_proxy.py")
 SEC = "s3cr3t-test-token"
+
+
+def _start_capture_upstream():
+    bodies = []
+
+    class Capture(BaseHTTPRequestHandler):
+        def log_message(self, *a):
+            pass
+
+        def do_POST(self):
+            n = int(self.headers.get("Content-Length") or 0)
+            raw = self.rfile.read(n)
+            try:
+                bodies.append(json.loads(raw or b"{}"))
+            except Exception:
+                bodies.append(raw.decode("utf-8", "replace"))
+            body = json.dumps({
+                "id": "msg_mock", "type": "message", "role": "assistant",
+                "model": "mock", "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn", "stop_sequence": None,
+                "usage": {"input_tokens": 1, "output_tokens": 1},
+            }).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            self.send_response(404)
+            self.end_headers()
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), Capture)
+    port = srv.server_address[1]
+    import threading
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return f"http://127.0.0.1:{port}", bodies, srv.shutdown
 
 
 def _req(url, method="GET", body=None):
@@ -245,6 +283,60 @@ class ProxyQwenUpstreamErrorPassthrough(unittest.TestCase):
                     {"model": "claude-opus-4-8", "max_tokens": 1,
                      "messages": [{"role": "user", "content": "ping"}]})
         self.assertEqual(s, 401, f"qwen 也应保留上游 401，实收 {s} {b[:160]!r}")
+
+
+@unittest.skipUnless(loopback_available(), "env-blocked: loopback bind/connect not permitted")
+class ProxyRelayToolSchemaNormalization(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.up_base, cls.bodies, cls.stop_up = _start_capture_upstream()
+        port = 18997  # S0 全局唯一端口：ProxyRelayToolSchemaNormalization
+        cls.base = f"http://127.0.0.1:{port}"
+        cls.logf = os.path.join(tempfile.gettempdir(), f"csswitch-relay-tools-{port}.log")
+        open(cls.logf, "w").close()
+        env = dict(os.environ, CSSWITCH_RELAY_KEY="fake-relay-key",
+                   CSSWITCH_RELAY_BASE_URL=cls.up_base,
+                   CSSWITCH_RELAY_MODEL="MiniMax-M2")
+        cls.proc = subprocess.Popen(
+            [sys.executable, PROXY, "--provider", "relay",
+             "--port", str(port), "--auth-token", SEC, "--log", cls.logf],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        for _ in range(50):
+            try:
+                s, _b = _req(f"{cls.base}/{SEC}/health")
+                if s == 200:
+                    break
+            except Exception:
+                pass
+            time.sleep(0.1)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.proc.terminate()
+        cls.proc.wait(timeout=5)
+        cls.stop_up()
+
+    def test_relay_outbound_tools_are_normalized_before_provider(self):
+        s, b = _req(f"{self.base}/{SEC}/v1/messages", "POST", {
+            "model": "claude-opus-4-8",
+            "max_tokens": 10,
+            "messages": [{"role": "user", "content": "hi"}],
+            "tool_choice": {"type": "tool", "name": "removed"},
+            "tools": [
+                {"name": "empty", "input_schema": {}},
+                {"name": "bad_required", "input_schema": {
+                    "type": "object", "properties": [], "required": "q",
+                }},
+                {"name": "", "input_schema": {"type": "object"}},
+            ],
+        })
+        self.assertEqual(s, 200, b[:160])
+        out = self.bodies[-1]
+        self.assertEqual(out["model"], "MiniMax-M2")
+        self.assertEqual([t["name"] for t in out["tools"]], ["empty", "bad_required"])
+        self.assertEqual(out["tools"][0]["input_schema"], {"type": "object", "properties": {}})
+        self.assertEqual(out["tools"][1]["input_schema"], {"type": "object", "properties": {}})
+        self.assertEqual(out["tool_choice"], {"type": "auto"})
 
 
 class ProxyOpenAICustomModelsDiscovery(unittest.TestCase):


### PR DESCRIPTION
## Summary
- record the current Claude Science native baseline drift: installed 0.1.0-dev vs local cached 0.1.15-dev route evidence
- normalize relay Anthropic-compatible tool schemas before outbound requests so empty/invalid input_schema values become object schemas
- drop malformed/no-name tools and downgrade forced tool_choice to auto when its target tool was removed

Fixes #18.

## Validation
- python3 -m unittest test.test_anthropic_compat test.test_proxy_units -v
- python3 -m unittest test.test_proxy_auth.ProxyRelayToolSchemaNormalization -v
- python3 -m unittest discover -s test -v (rerun passed after one transient DSML stream timing failure)
- node --check desktop/src/main.js
- git diff --check
- cargo fmt --check (from desktop/src-tauri)
- cargo test --all-targets (from desktop/src-tauri)
- cargo clippy --all-targets -- -D warnings (from desktop/src-tauri)
- bash test/run_all.sh --require-release-ready

## Boundaries
- Did not run real Claude Science/provider E2E.
- Did not read or modify real ~/.claude-science, and did not use port 8765.
- Did not verify GUI E2E, DMG, codesign, or notarization.
- #26 is not claimed fixed; it still needs post-merge or user-side retest.