### PR TITLE
docs/test: add static capability catalog v1

### DIFF
--- a/catalog/capabilities.v1.json
+++ b/catalog/capabilities.v1.json
@@ -1,0 +1,421 @@
+{
+  "schema_version": 1,
+  "providers": [
+    {
+      "id": "provider.deepseek.anthropic-native",
+      "scope": "provider",
+      "match": {
+        "provider": "deepseek",
+        "api_format": "anthropic"
+      },
+      "status": "supported",
+      "action": "normalize",
+      "reason": "DeepSeek uses the native Anthropic path; CSSwitch maps Science shell model ids, clamps known token caps, and normalizes thinking/tool_choice quirks.",
+      "evidence": [
+        "proxy/csswitch_proxy.py:51",
+        "proxy/provider_policy.py:69",
+        "docs/verified-facts.md:34"
+      ],
+      "tests": [
+        "test.test_provider_policy.ResolveModelDeepseek",
+        "test.test_provider_policy.ThinkingNormalization.test_deepseek_forced_tool_choice_disables_thinking"
+      ]
+    },
+    {
+      "id": "provider.relay.force-model-shell",
+      "scope": "model",
+      "match": {
+        "provider": "relay",
+        "condition": "relay_force_model present"
+      },
+      "status": "supported",
+      "action": "normalize",
+      "reason": "Formal relay/custom proxies return one Science-visible claude-opus shell model with the real model name in display_name; outbound requests are force-overridden to the selected real model.",
+      "evidence": [
+        "proxy/csswitch_proxy.py:344",
+        "proxy/model_discovery.py:32",
+        "docs/known-issues.md:132"
+      ],
+      "tests": [
+        "test.test_proxy_units.BuildModelsResponse.test_force_returns_single_shell",
+        "test.test_proxy_auth.ProxyOpenAIForcedModels.test_formal_proxy_returns_claude_shell_for_science_selector"
+      ]
+    },
+    {
+      "id": "provider.kimi.relay-thinking-enabled",
+      "scope": "provider",
+      "match": {
+        "provider": "relay",
+        "model_contains": "kimi",
+        "thinking_policy": "enabled"
+      },
+      "status": "limited",
+      "action": "degrade",
+      "reason": "Kimi relay models require enabled thinking, but forced Anthropic tool_choice is removed so the model can choose tools itself.",
+      "evidence": [
+        "desktop/src-tauri/src/templates.rs:120",
+        "proxy/provider_policy.py:103"
+      ],
+      "tests": [
+        "test.test_provider_policy.ThinkingNormalization.test_relay_enabled_policy_drops_forced_tool_choice"
+      ]
+    },
+    {
+      "id": "provider.dashscope.responses-tools-cap",
+      "scope": "provider",
+      "match": {
+        "api_format": "openai_responses",
+        "base_url_contains": "dashscope.aliyuncs.com",
+        "has_tools": true
+      },
+      "status": "limited",
+      "action": "degrade",
+      "reason": "DashScope Responses tool requests use a conservative max_output_tokens cap to avoid provider-side rejection.",
+      "evidence": [
+        "proxy/responses_compat.py:29"
+      ],
+      "tests": [
+        "test.test_proxy_units.ResponsesMapping.test_dashscope_responses_tool_requests_use_conservative_cap"
+      ]
+    }
+  ],
+  "tool_rules": [
+    {
+      "id": "tool.kimi.web_search.server-tool-filter",
+      "scope": "tool",
+      "match": {
+        "provider": "relay",
+        "model_contains": "kimi",
+        "tool_name": "web_search"
+      },
+      "status": "limited",
+      "action": "drop",
+      "reason": "Kimi treats web_search as a provider server tool and may stream server_tool_use/web_search_tool_result blocks; CSSwitch keeps local known_tools but does not advertise web_search upstream and filters server-tool blocks.",
+      "evidence": [
+        "proxy/anthropic_compat.py:84",
+        "proxy/anthropic_compat.py:178"
+      ],
+      "tests": [
+        "test.test_anthropic_compat.TransformRequest.test_kimi_relay_does_not_advertise_web_search_server_tool",
+        "test.test_anthropic_compat.MakeStreamRewriter.test_kimi_filter_drops_server_tool_blocks_and_compacts_indexes"
+      ]
+    },
+    {
+      "id": "tool.relay.input-schema-normalize",
+      "scope": "tool",
+      "match": {
+        "provider": "relay",
+        "schema_field": "input_schema"
+      },
+      "status": "supported",
+      "action": "normalize",
+      "reason": "Anthropic-compatible relay providers can reject empty or loose input_schema values, so CSSwitch normalizes relay tools to object schemas without mutating the caller request.",
+      "evidence": [
+        "proxy/anthropic_compat.py:26",
+        "proxy/anthropic_compat.py:56"
+      ],
+      "tests": [
+        "test.test_anthropic_compat.TransformRequest.test_relay_normalizes_loose_tool_schemas",
+        "test.test_proxy_auth.ProxyRelayTools.test_relay_outbound_tools_are_normalized_before_provider"
+      ]
+    },
+    {
+      "id": "tool.deepseek.forced-tool-choice-disable-thinking",
+      "scope": "tool",
+      "match": {
+        "provider": "deepseek",
+        "tool_choice_type": [
+          "any",
+          "tool"
+        ]
+      },
+      "status": "supported",
+      "action": "normalize",
+      "reason": "DeepSeek rejects forced tool use combined with thinking, so CSSwitch disables thinking for forced Anthropic tool_choice on DeepSeek.",
+      "evidence": [
+        "proxy/provider_policy.py:103",
+        "docs/verified-facts.md:38"
+      ],
+      "tests": [
+        "test.test_provider_policy.ThinkingNormalization.test_deepseek_forced_tool_choice_disables_thinking"
+      ]
+    },
+    {
+      "id": "tool.dashscope.responses.web_search-drop",
+      "scope": "tool",
+      "match": {
+        "api_format": "openai_responses",
+        "base_url_contains": "dashscope.aliyuncs.com",
+        "tool_name": "web_search"
+      },
+      "status": "limited",
+      "action": "drop",
+      "reason": "DashScope Responses-compatible endpoints reject web_search in this path, so CSSwitch drops that tool while preserving other function tools.",
+      "evidence": [
+        "proxy/responses_compat.py:58"
+      ],
+      "tests": [
+        "test.test_proxy_units.ResponsesMapping.test_dashscope_responses_drops_incompatible_web_search_tool"
+      ]
+    },
+    {
+      "id": "tool.dsml.deepseek-tooluse-rewrite",
+      "scope": "tool",
+      "match": {
+        "provider": "deepseek",
+        "shim_mode": "rewrite",
+        "leak_format": "DSML"
+      },
+      "status": "limited",
+      "action": "normalize",
+      "reason": "When explicitly enabled, the DSML shim can turn known leaked DSML tool calls back into Anthropic tool_use blocks; default runtime behavior remains off.",
+      "evidence": [
+        "proxy/dsml_shim.py",
+        "docs/known-issues.md:164"
+      ],
+      "tests": [
+        "test.test_dsml_shim",
+        "test.test_proxy_dsml_e2e"
+      ]
+    }
+  ],
+  "mcp_servers": [
+    {
+      "id": "mcp.hosted-anthropic.hcls-boundary",
+      "scope": "mcp",
+      "match": {
+        "transport": "hosted",
+        "servers": [
+          "pubmed",
+          "clinical-trials",
+          "chembl",
+          "biorxiv"
+        ],
+        "auth": "anthropic-hosted"
+      },
+      "status": "unsupported",
+      "action": "diagnose",
+      "reason": "Anthropic-hosted MCP servers require real claude.ai authorization and user:mcp_servers scope; CSSwitch virtual OAuth cannot make official hosted services available.",
+      "evidence": [
+        "docs/verified-facts.md:13",
+        "docs/known-issues.md:167"
+      ],
+      "tests": []
+    },
+    {
+      "id": "mcp.streamable-http.external-bio",
+      "scope": "mcp",
+      "match": {
+        "transport": "streamable_http",
+        "servers": [
+          "pubmed",
+          "clinical-trials",
+          "chembl",
+          "biorxiv"
+        ]
+      },
+      "status": "limited",
+      "action": "diagnose",
+      "reason": "External Streamable HTTP MCP servers depend on outbound network routing; current CONNECT tunneling is direct unless a future upstream proxy path is added.",
+      "evidence": [
+        "https://github.com/SuperJJ007/CSSwitch/issues/11",
+        "proxy/csswitch_proxy.py:532",
+        "scripts/launch-virtual-sandbox.sh:112"
+      ],
+      "tests": [
+        "test.test_proxy_connect.ProxyConnect.test_connect_passthrough_tunnels_bytes"
+      ]
+    },
+    {
+      "id": "mcp.local-stdio.bio-connectors",
+      "scope": "mcp",
+      "match": {
+        "transport": "stdio",
+        "domain": "bio"
+      },
+      "status": "unknown",
+      "action": "document",
+      "reason": "Local stdio bio connectors are the preferred fallback for hosted MCP boundaries, but installation, discovery, and restart persistence need explicit verification before support can be claimed.",
+      "evidence": [
+        "https://github.com/SuperJJ007/CSSwitch/pull/10"
+      ],
+      "tests": []
+    },
+    {
+      "id": "mcp.directory-connectors.virtual-login",
+      "scope": "mcp",
+      "match": {
+        "capability": "Directory connectors",
+        "auth": "virtual_oauth"
+      },
+      "status": "unsupported",
+      "action": "diagnose",
+      "reason": "Directory connectors are hosted claude.ai capabilities and can report unavailable or session expired under virtual login.",
+      "evidence": [
+        "docs/known-issues.md:170"
+      ],
+      "tests": []
+    }
+  ],
+  "skills": [
+    {
+      "id": "skill.local-or-github.discoverability",
+      "scope": "skill",
+      "match": {
+        "source": [
+          "local",
+          "github"
+        ]
+      },
+      "status": "unknown",
+      "action": "diagnose",
+      "reason": "Local and GitHub skills need post-install discoverability checks; storing or installing a skill is not enough to prove Science can use it.",
+      "evidence": [
+        "docs/known-issues.md:167"
+      ],
+      "tests": []
+    },
+    {
+      "id": "skill.remote-official.virtual-login-boundary",
+      "scope": "skill",
+      "match": {
+        "source": "remote_official",
+        "auth": "virtual_oauth"
+      },
+      "status": "unsupported",
+      "action": "diagnose",
+      "reason": "Official remote skills may depend on claude.ai hosted services and real account state; CSSwitch can document local alternatives but cannot promise hosted remote skill availability.",
+      "evidence": [
+        "docs/known-issues.md:167",
+        "docs/verified-facts.md:13"
+      ],
+      "tests": []
+    }
+  ],
+  "science_versions": [
+    {
+      "id": "science.version.0_1_0_dev_20260630",
+      "scope": "science_version",
+      "match": {
+        "version": "0.1.0-dev.20260630.t212931.sha2bc1ac8"
+      },
+      "status": "supported",
+      "action": "document",
+      "reason": "The installed /Applications Claude Science baseline has verified Info.plist and --version evidence; do not infer newer native routes from this seed.",
+      "evidence": [
+        "docs/verified-facts.md:19",
+        "docs/known-issues.md:34"
+      ],
+      "tests": []
+    },
+    {
+      "id": "science.version.0_1_15_dev.route-diff",
+      "scope": "science_version",
+      "match": {
+        "version": "0.1.15-dev.20260701.t220242.shaaa553de"
+      },
+      "status": "limited",
+      "action": "document",
+      "reason": "Local binary evidence records new auth nonce, auth, conda/pypi remote, token-series, preferences, and skills resync routes; these require isolated retest before runtime claims.",
+      "evidence": [
+        "docs/verified-facts.md:21",
+        "docs/verified-facts.md:22",
+        "docs/known-issues.md:30"
+      ],
+      "tests": []
+    },
+    {
+      "id": "science.auth.virtual-oauth-scope-boundary",
+      "scope": "science_version",
+      "match": {
+        "auth": "virtual_oauth",
+        "scopes_contains": [
+          "user:mcp_servers",
+          "user:plugins"
+        ]
+      },
+      "status": "limited",
+      "action": "document",
+      "reason": "Virtual OAuth can satisfy local Science inference/auth status paths, but listing scopes in local token material does not grant hosted claude.ai capabilities.",
+      "evidence": [
+        "docs/verified-facts.md:13",
+        "desktop/src-tauri/src/oauth_forge.rs:338"
+      ],
+      "tests": []
+    }
+  ],
+  "transport_rules": [
+    {
+      "id": "transport.connect.anthropic-fastfail-401",
+      "scope": "transport",
+      "match": {
+        "method": "CONNECT",
+        "host_suffixes": [
+          "anthropic.com",
+          "claude.ai",
+          "claude.com"
+        ]
+      },
+      "status": "supported",
+      "action": "diagnose",
+      "reason": "Anthropic/Claude hosts are fast-failed with 401 so Science treats virtual login as logged out instead of retrying organization switching.",
+      "evidence": [
+        "proxy/csswitch_proxy.py:206",
+        "proxy/csswitch_proxy.py:532"
+      ],
+      "tests": [
+        "test.test_proxy_connect.ProxyConnect.test_connect_anthropic_domains_fastfail_401",
+        "test.test_proxy_connect.ProxyConnect.test_connect_subdomain_of_blocked_is_blocked"
+      ]
+    },
+    {
+      "id": "transport.connect.non-anthropic-direct-tunnel",
+      "scope": "transport",
+      "match": {
+        "method": "CONNECT",
+        "host": "non_anthropic"
+      },
+      "status": "limited",
+      "action": "document",
+      "reason": "Non-Anthropic CONNECT currently opens a direct TCP tunnel; external MCP access can fail on networks where direct egress is blocked.",
+      "evidence": [
+        "proxy/csswitch_proxy.py:554",
+        "https://github.com/SuperJJ007/CSSwitch/issues/11"
+      ],
+      "tests": [
+        "test.test_proxy_connect.ProxyConnect.test_connect_passthrough_tunnels_bytes"
+      ]
+    },
+    {
+      "id": "transport.http-proxy.not-set-by-default",
+      "scope": "transport",
+      "match": {
+        "env": "http_proxy",
+        "launcher": "launch-virtual-sandbox"
+      },
+      "status": "limited",
+      "action": "document",
+      "reason": "The virtual sandbox intentionally does not set http_proxy because the CSSwitch proxy does not implement ordinary absolute-form HTTP forwarding.",
+      "evidence": [
+        "scripts/launch-virtual-sandbox.sh:115"
+      ],
+      "tests": []
+    },
+    {
+      "id": "transport.upstream-proxy.planned-for-http-mcp",
+      "scope": "transport",
+      "match": {
+        "capability": "upstream_proxy",
+        "use_case": "external_streamable_http_mcp"
+      },
+      "status": "unknown",
+      "action": "document",
+      "reason": "An upstream proxy path is the recommended future fix for external MCP egress, but it is not implemented in the current main branch.",
+      "evidence": [
+        "https://github.com/SuperJJ007/CSSwitch/pull/14",
+        "proxy/http_transport.py"
+      ],
+      "tests": []
+    }
+  ]
+}

--- a/docs/capability-catalog-design.md
+++ b/docs/capability-catalog-design.md
@@ -1,0 +1,93 @@
+# CSSwitch 能力 / 兼容性 Catalog 设计
+
+本设计定义第一版静态只读 catalog。它不是 MCP-only catalog，而是把 provider/model、工具调用、MCP/skill、Science native route/version、transport/network 的已知兼容性事实放到同一个机器可读入口里。
+
+第一版只新增数据文件和校验测试，不接 runtime、不改变代理行为、不改变 UI。目标是先把已经存在于源码、测试、issue 和文档里的隐式规则显式化，后续再小步接入 diagnostics、proxy rule lookup 或 UI 展示。
+
+## 边界
+
+CSSwitch 能维护和逐步自动化的范围：
+
+- 代理协议兼容：Anthropic passthrough、OpenAI Chat、OpenAI Responses、model shell、tool_choice、thinking、token cap。
+- 工具兼容：工具 schema 归一化、provider/model 级工具黑名单、server-tool block 过滤、DSML tool_use 兜底。
+- 本地替代路径：本地 stdio MCP、本地/GitHub skill 的安装引导和可发现性验收。
+- 网络/transport：Anthropic host fast-fail、CONNECT 行为、未来 upstream proxy 诊断。
+- Science native version：已知 route/version 差异、隔离复测要求、哪些能力不能从旧版本外推。
+
+CSSwitch 不能仅靠 catalog 承诺的范围：
+
+- Anthropic-hosted MCP、Directory connectors、官方 remote skills、官方 claude.ai 托管能力。
+- 真实账号态、真实 OAuth scope、真实 `~/.claude-science` live 状态。
+- 未隔离复测的 Science/provider GUI E2E、DMG、codesign、notarization。
+
+这些边界必须在 catalog 中标成 `unsupported`、`limited` 或 `unknown`，并以 `diagnose` / `document` 动作表达，而不是包装成“已支持”。
+
+## 文件与 Schema
+
+第一版文件位置：
+
+- `catalog/capabilities.v1.json`
+- `test/test_capability_catalog.py`
+
+顶层结构固定：
+
+```json
+{
+  "schema_version": 1,
+  "providers": [],
+  "tool_rules": [],
+  "mcp_servers": [],
+  "skills": [],
+  "science_versions": [],
+  "transport_rules": []
+}
+```
+
+每条 entry 使用统一最小字段集：
+
+```json
+{
+  "id": "stable-string-id",
+  "scope": "provider|model|tool|mcp|skill|science_version|transport",
+  "match": {},
+  "status": "supported|limited|unsupported|unknown",
+  "action": "none|normalize|drop|disable|degrade|diagnose|document",
+  "reason": "short human-readable reason",
+  "evidence": ["file-or-issue-reference"],
+  "tests": ["test name or empty"]
+}
+```
+
+字段含义：
+
+- `id`：稳定规则 ID，用于测试、诊断、未来 UI 链接。
+- `scope`：规则所属能力域。`model` 仍放在 `providers` section 内，表示 provider/model catalog 的子类。
+- `match`：非执行 DSL，只描述当前规则适用条件；v1 不要求 runtime 解释。
+- `status`：当前事实状态。`supported` 必须已有代码和测试或明确文档证据；`limited` 表示支持有条件或存在边界；`unsupported` 表示明确不能由 CSSwitch 修通；`unknown` 表示候选方向仍需探针。
+- `action`：当前或未来处理方式。v1 只记录，不驱动代码。
+- `evidence`：必须非空，可以是源码、测试、docs、issue/PR URL。
+- `tests`：可以为空；为空表示该事实目前只能由文档/issue 或未来探针约束。
+
+## 首批规则
+
+v1 catalog 只登记已知事实：
+
+- Kimi relay：`web_search` 会被视作 provider server tool；CSSwitch 不上送该 local client tool，并过滤 `server_tool_use` / `web_search_tool_result`。
+- Relay Anthropic-compatible：空或松散 `input_schema` 会归一化成 object schema。
+- DeepSeek：forced `tool_choice` 时禁用 thinking。
+- Kimi relay thinking：`thinking_policy=enabled` 时去掉 forced `tool_choice`，保留 tools。
+- DashScope/OpenAI Responses：drop `web_search`，带工具时使用 conservative output cap。
+- Science model selector：正式 force 模型时返回 `claude-opus-4-8` 壳，真实模型名放 `display_name`。
+- Hosted MCP / Directory connectors：虚拟 OAuth 下是官方托管能力边界，只能诊断和提供本地替代方向。
+- Streamable HTTP MCP：外部 HTTP MCP 依赖 transport/upstream proxy 能力，当前标 `limited`。
+- Science `0.1.0-dev` / `0.1.15-dev`：记录 route/version 差异，尤其 auth nonce、conda/pypi remote、skills resync。
+- Transport：Anthropic domains CONNECT 401 fast-fail；非 Anthropic CONNECT 当前 direct tunnel；ordinary HTTP proxy/upstream proxy 仍不是已实现 runtime 能力。
+
+## 后续接入顺序
+
+1. 静态 catalog + 校验测试。
+2. diagnostics 读取 catalog，只展示“已知边界/建议复测”，不改变运行行为。
+3. proxy rule lookup，把已存在的硬编码规则逐步改为从 catalog 或编译时派生结构读取。
+4. UI 展示 capability details，并为 MCP/skill 提供本地替代安装和可发现性验收入口。
+
+每一步都必须保持当前安全边界：不读写真实 `~/.claude-science`，不使用 `8765`，不把真实账号态或官方托管能力说成已验证。

--- a/test/run-offline.sh
+++ b/test/run-offline.sh
@@ -5,7 +5,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"; cd "$ROOT"
 if ! command -v python3 >/dev/null 2>&1; then
   echo "S0_LAYER offline env-blocked (no python3)"; exit 0
 fi
-if python3 -m unittest test.test_proxy_units test.test_provider_policy test.test_anthropic_compat test.test_dsml_shim test.test_capability -v; then
+if python3 -m unittest test.test_proxy_units test.test_provider_policy test.test_anthropic_compat test.test_dsml_shim test.test_capability test.test_capability_catalog -v; then
   echo "S0_LAYER offline pass"; exit 0
 else
   echo "S0_LAYER offline fail"; exit 1

--- a/test/test_capability_catalog.py
+++ b/test/test_capability_catalog.py
@@ -1,0 +1,111 @@
+import json
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CATALOG = ROOT / "catalog" / "capabilities.v1.json"
+
+SECTIONS = [
+    "providers",
+    "tool_rules",
+    "mcp_servers",
+    "skills",
+    "science_versions",
+    "transport_rules",
+]
+
+REQUIRED_FIELDS = {
+    "id",
+    "scope",
+    "match",
+    "status",
+    "action",
+    "reason",
+    "evidence",
+    "tests",
+}
+
+ALLOWED_SCOPES = {
+    "provider",
+    "model",
+    "tool",
+    "mcp",
+    "skill",
+    "science_version",
+    "transport",
+}
+
+ALLOWED_STATUS = {
+    "supported",
+    "limited",
+    "unsupported",
+    "unknown",
+}
+
+ALLOWED_ACTIONS = {
+    "none",
+    "normalize",
+    "drop",
+    "disable",
+    "degrade",
+    "diagnose",
+    "document",
+}
+
+REQUIRED_RULE_IDS = {
+    "tool.kimi.web_search.server-tool-filter",
+    "tool.relay.input-schema-normalize",
+    "tool.dashscope.responses.web_search-drop",
+    "mcp.hosted-anthropic.hcls-boundary",
+    "science.version.0_1_15_dev.route-diff",
+    "transport.connect.anthropic-fastfail-401",
+}
+
+
+def load_catalog():
+    with CATALOG.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+class CapabilityCatalogSchema(unittest.TestCase):
+    def test_catalog_json_loads_and_has_v1_shape(self):
+        data = load_catalog()
+        self.assertEqual(data["schema_version"], 1)
+        self.assertEqual(set(data), {"schema_version", *SECTIONS})
+        for section in SECTIONS:
+            self.assertIsInstance(data[section], list, section)
+
+    def test_entries_have_required_fields_and_valid_enums(self):
+        data = load_catalog()
+        for section in SECTIONS:
+            for entry in data[section]:
+                with self.subTest(section=section, rule_id=entry.get("id")):
+                    self.assertEqual(set(entry), REQUIRED_FIELDS)
+                    self.assertIsInstance(entry["id"], str)
+                    self.assertTrue(entry["id"].strip())
+                    self.assertIn(entry["scope"], ALLOWED_SCOPES)
+                    self.assertIn(entry["status"], ALLOWED_STATUS)
+                    self.assertIn(entry["action"], ALLOWED_ACTIONS)
+                    self.assertIsInstance(entry["match"], dict)
+                    self.assertIsInstance(entry["reason"], str)
+                    self.assertTrue(entry["reason"].strip())
+                    self.assertIsInstance(entry["evidence"], list)
+                    self.assertTrue(entry["evidence"], "evidence must not be empty")
+                    self.assertTrue(all(isinstance(x, str) and x.strip() for x in entry["evidence"]))
+                    self.assertIsInstance(entry["tests"], list)
+                    self.assertTrue(all(isinstance(x, str) and x.strip() for x in entry["tests"]))
+
+    def test_rule_ids_are_unique_and_key_rules_exist(self):
+        data = load_catalog()
+        ids = [
+            entry["id"]
+            for section in SECTIONS
+            for entry in data[section]
+        ]
+        self.assertEqual(len(ids), len(set(ids)), "catalog rule ids must be unique")
+        self.assertTrue(REQUIRED_RULE_IDS.issubset(set(ids)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `catalog/capabilities.v1.json` as a static v1 capability/rule catalog
- document the catalog shape and boundaries in `docs/capability-catalog-design.md`
- add schema/required-rule validation and wire it into the offline test layer

## Stack
- PR A of 3
- Base: `main`
- Next: `codex/catalog-loader-diagnostics`

## Boundaries
- Static data, docs, and tests only
- No runtime loading
- No proxy behavior changes
- No UI consumption

## Validation
- `bash test/run_all.sh --require-release-ready`
- Independent subagent validation reran `bash test/run_all.sh --require-release-ready`: release-ready green
- Subagent read-only review found no blocking public-safety issues for this PR boundary
