### PR TITLE
feat: add proxy rule id observability

### DIFF
--- a/proxy/anthropic_compat.py
+++ b/proxy/anthropic_compat.py
@@ -21,6 +21,7 @@ class Ctx:
     nonce: str
     shim_mode: str
     provider: str
+    rule_ids: tuple = ()
 
 
 def _normalize_relay_input_schema(schema):
@@ -53,7 +54,12 @@ def _degrade_missing_tool_choice(upstream):
         upstream["tool_choice"] = {"type": "auto"}
 
 
-def _normalize_relay_tools(upstream):
+def _append_rule_id(rule_ids, rule_id):
+    if rule_ids is not None and rule_id not in rule_ids:
+        rule_ids.append(rule_id)
+
+
+def _normalize_relay_tools(upstream, rule_ids=None):
     """Normalize Anthropic-compatible relay tool schemas before outbound.
 
     Some Anthropic-compatible relay providers reject Claude Science's empty or loose
@@ -74,6 +80,7 @@ def _normalize_relay_tools(upstream):
         clean = dict(tool)
         clean["input_schema"] = _normalize_relay_input_schema(tool.get("input_schema"))
         normalized.append(clean)
+    _append_rule_id(rule_ids, provider_policy.RULE_TOOL_RELAY_INPUT_SCHEMA_NORMALIZE)
     if normalized:
         upstream["tools"] = normalized
     else:
@@ -81,7 +88,7 @@ def _normalize_relay_tools(upstream):
     _degrade_missing_tool_choice(upstream)
 
 
-def _filter_upstream_tools(upstream, target_model, provider):
+def _filter_upstream_tools(upstream, target_model, provider, rule_ids=None):
     """Provider-specific tool compatibility before sending to upstream.
 
     Kimi's Anthropic endpoint treats a tool named ``web_search`` as its own server tool and
@@ -91,12 +98,13 @@ def _filter_upstream_tools(upstream, target_model, provider):
     """
     if provider != "relay":
         return
-    _normalize_relay_tools(upstream)
+    _normalize_relay_tools(upstream, rule_ids)
     if "kimi" in (target_model or "").lower():
         tools = upstream.get("tools")
         if isinstance(tools, list):
             filtered = [t for t in tools if not (isinstance(t, dict) and t.get("name") == "web_search")]
             if len(filtered) != len(tools):
+                _append_rule_id(rule_ids, provider_policy.RULE_TOOL_KIMI_WEB_SEARCH_SERVER_TOOL_FILTER)
                 if filtered:
                     upstream["tools"] = filtered
                 else:
@@ -109,18 +117,33 @@ def transform_request(body, state):
     等价于旧 _handle_anthropic 的 :695-702 + :714-718。"""
     src = body.get("model", "?")
     target = provider_policy.resolve_model(src, state)
+    rule_ids = []
+    if state.prov_name == "relay" and state.policy.force_model_override and state.relay_force_model:
+        _append_rule_id(rule_ids, provider_policy.RULE_PROVIDER_RELAY_FORCE_MODEL_SHELL)
+    if (
+        state.prov_name == "relay"
+        and state.relay_thinking == "enabled"
+        and "kimi" in (target or "").lower()
+    ):
+        _append_rule_id(rule_ids, provider_policy.RULE_PROVIDER_KIMI_RELAY_THINKING_ENABLED)
     upstream = dict(body)
     upstream["model"] = target
     if upstream.get("max_tokens"):
         upstream["max_tokens"] = provider_policy.clamp_max_tokens(
             upstream["max_tokens"], target, state)
-    provider_policy.normalize_thinking(upstream, state.prov_name, state.relay_thinking)
-    _filter_upstream_tools(upstream, target, state.prov_name)
+    provider_policy.normalize_thinking(
+        upstream,
+        state.prov_name,
+        state.relay_thinking,
+        rule_ids=rule_ids,
+    )
+    _filter_upstream_tools(upstream, target, state.prov_name, rule_ids)
     known_tools = {t["name"]: (t.get("input_schema") or {})
                    for t in (body.get("tools") or [])
                    if isinstance(t, dict) and t.get("name")}
     ctx = Ctx(src_model=src, target_model=target, known_tools=known_tools,
-              nonce=state.nonce_factory(), shim_mode=state.shim_mode, provider=state.prov_name)
+              nonce=state.nonce_factory(), shim_mode=state.shim_mode,
+              provider=state.prov_name, rule_ids=tuple(rule_ids))
     return upstream, ctx
 
 
@@ -276,7 +299,10 @@ class _KimiServerToolFilter:
         return self._rewrite_frame(frame, b"\n\n")
 
     def stats(self):
-        return {"dropped_kimi_server_tool_blocks": self._dropped}
+        out = {"dropped_kimi_server_tool_blocks": self._dropped}
+        if self._dropped:
+            out["rule_ids"] = [provider_policy.RULE_TOOL_KIMI_WEB_SEARCH_SERVER_TOOL_FILTER]
+        return out
 
 
 class _PipelineFilter:
@@ -298,7 +324,14 @@ class _PipelineFilter:
     def stats(self):
         out = {}
         for f in self._filters:
-            out.update(f.stats())
+            stats = f.stats()
+            if "rule_ids" in stats:
+                seen = out.setdefault("rule_ids", [])
+                for rule_id in stats["rule_ids"]:
+                    if rule_id not in seen:
+                        seen.append(rule_id)
+                stats = {k: v for k, v in stats.items() if k != "rule_ids"}
+            out.update(stats)
         return out
 
 

--- a/proxy/csswitch_proxy.py
+++ b/proxy/csswitch_proxy.py
@@ -406,7 +406,12 @@ def map_responses_tools(tools):
 
 
 def anthropic_to_openai_responses(req):
-    return responses_compat.anthropic_to_openai(
+    out, _metadata = anthropic_to_openai_responses_with_metadata(req)
+    return out
+
+
+def anthropic_to_openai_responses_with_metadata(req):
+    return responses_compat.anthropic_to_openai_with_metadata(
         req,
         _provider_state(req),
         _is_dashscope_responses(),
@@ -610,9 +615,10 @@ class H(BaseHTTPRequestHandler):
         upstream_body, ctx = anthropic_compat.transform_request(areq, state)
         stream = bool(upstream_body.get("stream"))
         n_tools = len(upstream_body.get("tools") or [])
+        rules = ",".join(ctx.rule_ids) if ctx.rule_ids else "-"
         log(f"POST /v1/messages  {ctx.src_model}->{ctx.target_model} stream={stream} "
             f"tools={n_tools} msgs={len(upstream_body.get('messages') or [])}  "
-            f"(入站鉴权已剥离, 直连 {runtime.prov_name})")
+            f"rules={rules}  (入站鉴权已剥离, 直连 {runtime.prov_name})")
         # 鉴权头按 provider 的 auth_style（deepseek x-api-key / relay both）。KEY 只驻内存、不入日志。
         headers = {"content-type": "application/json", "anthropic-version": "2023-06-01"}
         headers.update(_upstream_auth_headers(runtime))
@@ -715,15 +721,17 @@ class H(BaseHTTPRequestHandler):
         runtime = runtime or current_runtime()
         model_id = areq.get("model", "claude-sonnet-5")
         stream = bool(areq.get("stream"))
+        metadata = {"rule_ids": ()}
         if runtime.prov.get("api_format") == "openai_responses":
-            oreq = anthropic_to_openai_responses(areq)
+            oreq, metadata = anthropic_to_openai_responses_with_metadata(areq)
             msg_count = len(oreq.get("input") or [])
         else:
             oreq = anthropic_to_openai(areq)
             msg_count = len(oreq.get("messages") or [])
         n_tools = len(oreq.get("tools", []))
+        rules = ",".join(metadata.get("rule_ids") or ()) or "-"
         log(f"POST /v1/messages  {model_id}->{oreq['model']} stream={stream} tools={n_tools} "
-            f"msgs={msg_count}  (入站鉴权已剥离, {runtime.prov_name})")
+            f"msgs={msg_count} rules={rules}  (入站鉴权已剥离, {runtime.prov_name})")
         headers = {"Authorization": f"Bearer {runtime.key}", "Content-Type": "application/json"}
         data = json.dumps(oreq).encode()
         try:

--- a/proxy/provider_policy.py
+++ b/proxy/provider_policy.py
@@ -10,6 +10,16 @@ from typing import Callable
 
 _DATE_SUFFIX = re.compile(r"-\d{8}$")
 
+RULE_PROVIDER_RELAY_FORCE_MODEL_SHELL = "provider.relay.force-model-shell"
+RULE_PROVIDER_KIMI_RELAY_THINKING_ENABLED = "provider.kimi.relay-thinking-enabled"
+RULE_PROVIDER_DASHSCOPE_RESPONSES_TOOLS_CAP = "provider.dashscope.responses-tools-cap"
+RULE_TOOL_KIMI_WEB_SEARCH_SERVER_TOOL_FILTER = "tool.kimi.web_search.server-tool-filter"
+RULE_TOOL_RELAY_INPUT_SCHEMA_NORMALIZE = "tool.relay.input-schema-normalize"
+RULE_TOOL_DEEPSEEK_FORCED_TOOL_CHOICE_DISABLE_THINKING = (
+    "tool.deepseek.forced-tool-choice-disable-thinking"
+)
+RULE_TOOL_DASHSCOPE_RESPONSES_WEB_SEARCH_DROP = "tool.dashscope.responses.web_search-drop"
+
 
 @dataclass(frozen=True)
 class Policy:
@@ -99,7 +109,12 @@ def _enabled_budget(max_tokens):
     return default
 
 
-def normalize_thinking(body, prov_name, relay_thinking=None):
+def _append_rule_id(rule_ids, rule_id):
+    if rule_ids is not None and rule_id not in rule_ids:
+        rule_ids.append(rule_id)
+
+
+def normalize_thinking(body, prov_name, relay_thinking=None, rule_ids=None):
     """thinking 归一化（纯函数，签名与语义与旧 csswitch_proxy 版一致）。
       (A) 强制 tool_choice(any/tool) → disabled：仅 deepseek。
       (B) relay 的 thinking 策略：enabled（如 Kimi）/ adaptive|None（默认，如 MiniMax）。
@@ -109,6 +124,7 @@ def normalize_thinking(body, prov_name, relay_thinking=None):
     tc = body.get("tool_choice")
     forcing = isinstance(tc, dict) and tc.get("type") in ("any", "tool")
     if forcing and prov_name == "deepseek":
+        _append_rule_id(rule_ids, RULE_TOOL_DEEPSEEK_FORCED_TOOL_CHOICE_DISABLE_THINKING)
         body["thinking"] = {"type": "disabled"}
         return body
     if prov_name == "relay" and relay_thinking == "enabled":

--- a/proxy/responses_compat.py
+++ b/proxy/responses_compat.py
@@ -9,6 +9,11 @@ import json
 import provider_policy
 
 
+def _append_rule_id(rule_ids, rule_id):
+    if rule_ids is not None and rule_id not in rule_ids:
+        rule_ids.append(rule_id)
+
+
 def map_tool_choice(tc, tools):
     has_tools = bool(tools)
     if isinstance(tc, str):
@@ -26,11 +31,12 @@ def map_tool_choice(tc, tools):
     return None
 
 
-def max_output_tokens(req, model, state, has_tools, is_dashscope=False):
+def max_output_tokens(req, model, state, has_tools, is_dashscope=False, rule_ids=None):
     value = provider_policy.clamp_max_tokens(req.get("max_tokens"), model, state)
     if not value:
         return value
     if has_tools and is_dashscope:
+        _append_rule_id(rule_ids, provider_policy.RULE_PROVIDER_DASHSCOPE_RESPONSES_TOOLS_CAP)
         return min(int(value), 8192)
     return value
 
@@ -55,13 +61,14 @@ def normalize_tool_parameters(schema):
     return out
 
 
-def map_tools(tools, is_dashscope=False):
+def map_tools(tools, is_dashscope=False, rule_ids=None):
     out = []
     for t in tools or []:
         name = t.get("name")
         if not name:
             continue
         if is_dashscope and name == "web_search":
+            _append_rule_id(rule_ids, provider_policy.RULE_TOOL_DASHSCOPE_RESPONSES_WEB_SEARCH_DROP)
             continue
         out.append({
             "type": "function",
@@ -83,6 +90,12 @@ def _as_text(value):
 
 
 def anthropic_to_openai(req, state, is_dashscope=False):
+    out, _metadata = anthropic_to_openai_with_metadata(req, state, is_dashscope)
+    return out
+
+
+def anthropic_to_openai_with_metadata(req, state, is_dashscope=False):
+    rule_ids = []
     sys_prompt = req.get("system")
     if isinstance(sys_prompt, list):
         sys_prompt = "\n".join(b.get("text", "") for b in sys_prompt if isinstance(b, dict))
@@ -129,8 +142,15 @@ def anthropic_to_openai(req, state, is_dashscope=False):
     }
     if sys_prompt:
         out["instructions"] = sys_prompt
-    tools = map_tools(req.get("tools"), is_dashscope)
-    token_limit = max_output_tokens(req, out["model"], state, bool(tools), is_dashscope)
+    tools = map_tools(req.get("tools"), is_dashscope, rule_ids)
+    token_limit = max_output_tokens(
+        req,
+        out["model"],
+        state,
+        bool(tools),
+        is_dashscope,
+        rule_ids,
+    )
     if token_limit:
         out["max_output_tokens"] = token_limit
     if req.get("temperature") is not None:
@@ -142,7 +162,7 @@ def anthropic_to_openai(req, state, is_dashscope=False):
     tcm = map_tool_choice(req.get("tool_choice"), tools)
     if tcm is not None:
         out["tool_choice"] = tcm
-    return out
+    return out, {"rule_ids": tuple(rule_ids)}
 
 
 def output_text(item):

--- a/test/test_anthropic_compat.py
+++ b/test/test_anthropic_compat.py
@@ -92,6 +92,12 @@ class TransformRequest(unittest.TestCase):
         self.assertEqual(up["model"], "kimi-k2.7-code")
         self.assertEqual([t["name"] for t in up["tools"]], ["bash"])
         self.assertEqual(set(ctx.known_tools), {"web_search", "bash"})
+        self.assertEqual(ctx.rule_ids, (
+            pp.RULE_PROVIDER_RELAY_FORCE_MODEL_SHELL,
+            pp.RULE_PROVIDER_KIMI_RELAY_THINKING_ENABLED,
+            pp.RULE_TOOL_RELAY_INPUT_SCHEMA_NORMALIZE,
+            pp.RULE_TOOL_KIMI_WEB_SEARCH_SERVER_TOOL_FILTER,
+        ))
 
     def test_non_kimi_relay_keeps_web_search_tool(self):
         st = _state(dict(cs.PROVIDERS["relay"]), "relay",
@@ -126,6 +132,7 @@ class TransformRequest(unittest.TestCase):
         self.assertEqual(schemas["bad_props"], {"type": "object", "properties": {}})
         self.assertEqual(schemas["not_dict"], {"type": "object", "properties": {}})
         self.assertEqual(set(ctx.known_tools), {"empty", "props_only", "bad_props", "not_dict"})
+        self.assertIn(pp.RULE_TOOL_RELAY_INPUT_SCHEMA_NORMALIZE, ctx.rule_ids)
         self.assertEqual(body["tools"][0]["input_schema"], {}, "不应原地改调用者请求体")
 
     def test_relay_tool_choice_for_removed_tool_degrades_to_auto(self):
@@ -238,6 +245,7 @@ class MakeStreamRewriter(unittest.TestCase):
         self.assertIn(b'"index":2', out)
         self.assertIn(b'"text":"OK"', out)
         self.assertEqual(f.stats()["dropped_kimi_server_tool_blocks"], 2)
+        self.assertEqual(f.stats()["rule_ids"], [pp.RULE_TOOL_KIMI_WEB_SEARCH_SERVER_TOOL_FILTER])
 
     def test_rewrite_filter_synthesizes_tool_use(self):
         f = ac.make_stream_rewriter(

--- a/test/test_capability_catalog.py
+++ b/test/test_capability_catalog.py
@@ -1,10 +1,13 @@
 import json
 import pathlib
+import sys
 import unittest
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 CATALOG = ROOT / "catalog" / "capabilities.v1.json"
+sys.path.insert(0, str(ROOT / "proxy"))
+import provider_policy as pp
 
 SECTIONS = [
     "providers",
@@ -54,12 +57,26 @@ ALLOWED_ACTIONS = {
 }
 
 REQUIRED_RULE_IDS = {
+    "provider.relay.force-model-shell",
+    "provider.kimi.relay-thinking-enabled",
+    "provider.dashscope.responses-tools-cap",
     "tool.kimi.web_search.server-tool-filter",
     "tool.relay.input-schema-normalize",
+    "tool.deepseek.forced-tool-choice-disable-thinking",
     "tool.dashscope.responses.web_search-drop",
     "mcp.hosted-anthropic.hcls-boundary",
     "science.version.0_1_15_dev.route-diff",
     "transport.connect.anthropic-fastfail-401",
+}
+
+PROXY_RULE_ID_CONSTANTS = {
+    pp.RULE_PROVIDER_RELAY_FORCE_MODEL_SHELL,
+    pp.RULE_PROVIDER_KIMI_RELAY_THINKING_ENABLED,
+    pp.RULE_PROVIDER_DASHSCOPE_RESPONSES_TOOLS_CAP,
+    pp.RULE_TOOL_KIMI_WEB_SEARCH_SERVER_TOOL_FILTER,
+    pp.RULE_TOOL_RELAY_INPUT_SCHEMA_NORMALIZE,
+    pp.RULE_TOOL_DEEPSEEK_FORCED_TOOL_CHOICE_DISABLE_THINKING,
+    pp.RULE_TOOL_DASHSCOPE_RESPONSES_WEB_SEARCH_DROP,
 }
 
 
@@ -105,6 +122,15 @@ class CapabilityCatalogSchema(unittest.TestCase):
         ]
         self.assertEqual(len(ids), len(set(ids)), "catalog rule ids must be unique")
         self.assertTrue(REQUIRED_RULE_IDS.issubset(set(ids)))
+
+    def test_proxy_observability_rule_ids_are_cataloged(self):
+        data = load_catalog()
+        ids = {
+            entry["id"]
+            for section in SECTIONS
+            for entry in data[section]
+        }
+        self.assertTrue(PROXY_RULE_ID_CONSTANTS.issubset(ids))
 
 
 if __name__ == "__main__":

--- a/test/test_provider_policy.py
+++ b/test/test_provider_policy.py
@@ -103,7 +103,12 @@ class ClampMaxTokens(unittest.TestCase):
 class ThinkingNormalization(unittest.TestCase):
     def test_deepseek_forced_tool_choice_disables_thinking(self):
         body = {"tool_choice": {"type": "any"}, "thinking": {"type": "auto"}}
-        self.assertEqual(pp.normalize_thinking(body, "deepseek")["thinking"], {"type": "disabled"})
+        rule_ids = []
+        self.assertEqual(
+            pp.normalize_thinking(body, "deepseek", rule_ids=rule_ids)["thinking"],
+            {"type": "disabled"},
+        )
+        self.assertEqual(rule_ids, [pp.RULE_TOOL_DEEPSEEK_FORCED_TOOL_CHOICE_DISABLE_THINKING])
 
     def test_relay_forced_tool_choice_not_disabled(self):
         body = {"tool_choice": {"type": "tool", "name": "x"}, "thinking": {"type": "auto"}}

--- a/test/test_proxy_units.py
+++ b/test/test_proxy_units.py
@@ -91,7 +91,7 @@ class ResponsesMapping(unittest.TestCase):
         old_url = cs.PROV.get("url")
         cs.PROV["url"] = "https://dashscope.aliyuncs.com/compatible-mode/v1/responses"
         try:
-            out = cs.anthropic_to_openai_responses({
+            out, metadata = cs.anthropic_to_openai_responses_with_metadata({
                 "model": "claude-opus-4-8",
                 "messages": [{"role": "user", "content": "hi"}],
                 "max_tokens": 999999,
@@ -101,12 +101,13 @@ class ResponsesMapping(unittest.TestCase):
             cs.PROV["url"] = old_url
         self.assertEqual(out["max_output_tokens"], 8192)
         self.assertEqual(out["tool_choice"], "auto")
+        self.assertEqual(metadata["rule_ids"], ("provider.dashscope.responses-tools-cap",))
 
     def test_dashscope_responses_drops_incompatible_web_search_tool(self):
         old_url = cs.PROV.get("url")
         cs.PROV["url"] = "https://dashscope.aliyuncs.com/compatible-mode/v1/responses"
         try:
-            out = cs.anthropic_to_openai_responses({
+            out, metadata = cs.anthropic_to_openai_responses_with_metadata({
                 "model": "claude-opus-4-8",
                 "messages": [{"role": "user", "content": "hi"}],
                 "tools": [
@@ -118,6 +119,7 @@ class ResponsesMapping(unittest.TestCase):
             cs.PROV["url"] = old_url
         self.assertEqual([t["name"] for t in out["tools"]], ["lookup"])
         self.assertEqual(out["tools"][0]["parameters"]["type"], "object")
+        self.assertEqual(metadata["rule_ids"], ("tool.dashscope.responses.web_search-drop",))
 
     def test_non_dashscope_responses_keeps_web_search_tool(self):
         out = cs.anthropic_to_openai_responses({


### PR DESCRIPTION
## Summary
- add stable proxy-side rule id constants that match the static catalog
- attach matched rule ids to Anthropic proxy transform context and stream stats
- add Responses conversion metadata without changing outbound request payloads
- log only fixed rule ids for diagnostics, not secrets or request bodies

## Stack
- PR C of 3
- Base: `codex/catalog-loader-diagnostics` / PR #35

## Boundaries
- Observability metadata for existing Python proxy behavior only
- Does not migrate behavior decisions into the catalog
- Does not add debug fields to upstream JSON payloads
- Does not touch real Science HOME, port 8765, live provider credentials, GUI E2E, signing, or notarization

## Validation
- `bash test/run_all.sh --require-release-ready`
- Independent subagent validation reran `bash test/run_all.sh --require-release-ready`: release-ready green
- Subagent read-only review confirmed PR A/B/C boundaries and no blocking findings after the diagnostics P2 fix
