### PR TITLE
docs: clarify catalog diagnostics boundaries

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -29,6 +29,7 @@ It is built for more than developers. You need Claude Science, a third-party API
 - [What it can do](#what-it-can-do)
 - [Quick start](#quick-start)
 - [Supported model sources](#supported-model-sources)
+- [Status diagnostics and capability catalog](#status-diagnostics-and-capability-catalog)
 - [How it protects your real account](#how-it-protects-your-real-account)
 - [Current limitations](#current-limitations)
 - [Languages](#languages)
@@ -111,6 +112,12 @@ If you have a Claude subscription and want the normal official Science experienc
 | Custom OpenAI Responses | User-provided OpenAI Responses base root | The proxy appends `/responses` and `/models` |
 
 > If your URL is an `/anthropic` endpoint, choose "Custom Anthropic". If you choose "Custom OpenAI", enter an OpenAI-compatible base root such as `https://example.com/v1`, not an Anthropic endpoint.
+
+## Status diagnostics and capability catalog
+
+CSSwitch includes a read-only capability catalog that makes known compatibility boundaries explicit across providers, tool use, MCP/skills, Science versions, and transport behavior. Runtime `status` diagnostics return the catalog rules matched by the current profile plus fixed boundary rules, which helps explain why a configuration is handled a certain way and which capabilities are diagnostic-only or degraded.
+
+This catalog is for diagnostics and observability. It is not proof that a live provider, real Claude account state, Science GUI E2E flow, DMG signing/notarization, or official hosted capability has been verified. A catalog rule id means CSSwitch records that rule or boundary; it does not mean external providers, Anthropic-hosted MCP, Directory connectors, or remote skills are fully verified or fixed.
 
 ## How it protects your real account
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ CSSwitch 是一个给 Claude Science 使用的本地模型切换器。它把 Sci
 - [可以做什么](#可以做什么)
 - [快速开始](#快速开始)
 - [支持的模型来源](#支持的模型来源)
+- [状态诊断与能力 catalog](#状态诊断与能力-catalog)
 - [它如何保护你的真实账号](#它如何保护你的真实账号)
 - [哪些能力暂时用不了](#哪些能力暂时用不了)
 - [多语言](#多语言)
@@ -111,6 +112,12 @@ Claude Science sandbox
 | 自定义 OpenAI Responses | 自填 OpenAI Responses base root | 代理自动补 `/responses` 与 `/models` |
 
 > 如果你的地址是 `/anthropic` 端点，请选择「自定义 Anthropic」。如果选择「自定义 OpenAI」，请填写 OpenAI 兼容的 base root，例如 `https://example.com/v1`，不要填 Anthropic 端点。
+
+## 状态诊断与能力 catalog
+
+CSSwitch 内置了只读的 capability catalog，用来把 provider、工具调用、MCP/skill、Science 版本和 transport 的已知兼容性边界显式化。运行时 `status` 诊断会返回当前 profile 命中的 catalog 规则和固定边界规则，便于定位「当前配置为什么这样处理」以及「哪些能力只能诊断或降级」。
+
+这个 catalog 是诊断与可观测性入口，不是 live provider、真实 Claude 账号态、Science GUI E2E、DMG 签名/公证或官方托管能力的验证结果。看到 catalog rule id 只表示 CSSwitch 记录了对应规则或边界；不表示外部 provider、Anthropic-hosted MCP、Directory connectors、remote skills 已被完整验证或修通。
 
 ## 它如何保护你的真实账号
 

--- a/docs/provider-support.md
+++ b/docs/provider-support.md
@@ -3,6 +3,8 @@
 目标：CSSwitch 支持的第三方 API **尽量多**，慢慢实现。本文回答两个核心问题（到底走 Anthropic 端点还是 OpenAI 端点、Claude Science 的工具调用格式怎么处理），并给出候选 provider 清单与实现优先级。对应 roadmap 见 [`known-issues.md`](known-issues.md) 第 2 条。
 
 > 状态：**调研封存**（用户 2026-07-03 叫停）。#1 文案脱敏已完成；**本研究的落地切片「面板内自定义 OpenAI 端点」已定为 #1 之后的下个主线**（见 [`known-issues.md`](known-issues.md) 文末）。已定稿：核心分型、Science 工具调用格式与翻译坑、CC Switch 参考（第三节）、国际 provider 数据（已调研）。**待续**：把国产各家 OpenAI 端点 / 模型细节并成第四节大表（深挖 agent 中断）。
+>
+> 2026-07-08 维护注记：主线现已有静态 [`catalog/capabilities.v1.json`](../catalog/capabilities.v1.json) 和 runtime `status().catalog` diagnostics，用来暴露当前 profile 命中的 provider/tool 规则以及固定边界规则。它们是诊断与可观测性入口，不让 catalog 驱动代理行为，也不等同于 live provider、真实账号态、Science GUI E2E、DMG 签名/公证或官方托管 MCP/Directory/remote skill 能力已验证。
 
 ## 一、核心结论：到底是 Anthropic 端口还是 OpenAI 端点？
 


### PR DESCRIPTION
## Summary
- Document that runtime status diagnostics now include catalog rules and fixed boundary rules.
- Clarify that catalog diagnostics explain known rules and limits, but do not drive proxy behavior.
- Keep live provider, real account state, Science GUI E2E, DMG signing/notarization, and official hosted capability verification out of scope.

## Verification
- git diff --check
- python3 -m unittest test.test_capability_catalog -v

## Review gate
- Read-only subagent reviewed the docs diff for over-claims, anchors, and links; no blocking findings.