### PR TITLE
test/docs: record custom selector evidence

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -133,6 +133,8 @@
 
 > **状态：已实现 + 真机验证通过，已 merge 进 main（2026-07-04，分支 `feat/relay-model-shell` 8 commit FF 合入），待随 v0.3.2 发布。** 真机证据：沙箱 Science 顶部选择器显示真实模型名 `glm-5.2`（非 claude/opus），代理 `/v1/models` 在 force 时返回单壳 `{id:claude-opus-4-8, display_name:真实名}`；铁律全程守住（8765 与真实目录未碰）。对应用户 bug 清单 #11（智谱等显示 claude）+ #12 显示部分（自定义显示 opus）。**#12 的校验部分（自定义 scratch 探测误判 Ambiguous）仍待复现，未在本轮解决。**
 >
+> **2026-07-08 追加（#26 自定义 OpenAI / Responses 选择器空列表）：** 当前 main 已有本地隔离 proxy/mock 证据，正式 `openai-custom` 与 `openai-responses` profile 在已配置模型时，`/{secret}/v1/models` 只返回单壳 `claude-opus-4-8`，真实模型名放 `display_name`，且 force 模式不回源暴露第三方原始模型 id；见 [`findings/2026-07-08-issue-26-custom-selector-evidence.md`](../findings/2026-07-08-issue-26-custom-selector-evidence.md)。这仍不是真实 Science UI 截图、真实账号态或 published DMG 验证；若关闭 #26，应按“当前源码代理契约 + 隔离 mock 证据”表述。
+>
 > **修复摘要（对齐 deepseek 借壳 + cc-switch 自填范式，spec/plan 见本地 `docs/superpowers/`，git 忽略）**：① 层二＝代理 `build_models_response` 在 `RELAY_FORCE_MODEL` 设时返回单壳（`claude-opus-4-8` + `display_name`＝真实模型名），出站由 `resolve_model` 的 force 分支覆盖、零改动；② 层一＝全 relay 统一 FIXED（GLM/OpenRouter 也 `requires_model_override=true`），模型控件从 `<select>` 换成 `<input list>+<datalist>`（下拉精选＋自填兜底，`custom` 终于能填模型名）；③ 各家 `builtin_models` 官方核定（GLM→`glm-5.2`、MiniMax→`MiniMax-M3`、硅基→`DeepSeek-V4-Pro` 等，硅基 Anthropic `/v1/messages` 真机 200）；④ 后端 `relay_missing_model` 守卫接 create/edit/activate（不变量不可绕过）；⑤ 存量空 model 的 relay 加载时回填模板默认＋一次性提示（甲迁移）；⑥ 模型名 trim 规范化。原设计如下（历史留存）：
 
 - **现象**：① 智谱 GLM 等 relay 家在 Science 顶部模型选择器里「显示的是 claude」；② 自定义（填 claude 中转 API）「显示的是 opus」；用户说「自定义的模型也有问题」。

--- a/findings/2026-07-08-issue-26-custom-selector-evidence.md
+++ b/findings/2026-07-08-issue-26-custom-selector-evidence.md
@@ -1,0 +1,29 @@
+# Issue #26 custom model selector evidence
+
+Date: 2026-07-08
+
+Scope: local isolated proxy/mock evidence for issue #26. This file does not claim real Claude account state, real `~/.claude-science`, Science GUI E2E, published DMG, signing, notarization, or official hosted capability verification.
+
+## What is covered
+
+- `openai-custom` formal proxy with a selected model returns a single Science-visible shell model from `/{secret}/v1/models`:
+  - `id`: `claude-opus-4-8`
+  - `display_name`: the configured real model, such as `glm-4.5`
+- `openai-responses` formal proxy follows the same selector contract with `display_name` set to the configured real model, such as `gpt-5.2`.
+- In force mode, the selector response does not call the mock upstream `/models` endpoint, so raw third-party model ids are not exposed back to Science.
+- Proxy logs record the selector GET path as a force-shell response while avoiding API key output.
+
+## Evidence commands
+
+```bash
+python3 -m unittest test.test_proxy_units test.test_proxy_auth -v
+```
+
+The relevant assertions live in [`test/test_proxy_auth.py`](../test/test_proxy_auth.py):
+
+- `ProxyOpenAICustomForcedModelList.test_formal_proxy_returns_claude_shell_for_science_selector`
+- `ProxyOpenAIResponses.test_models_returns_claude_shell_for_science_selector`
+
+## Remaining boundary
+
+This is enough to prove the local proxy selector contract for #26 on the current source tree. It is not a real Science UI screenshot and is not proof that a previously published `v0.3.6` DMG contains this fix. Closing #26 as a product bug should either cite this as source-level evidence only or add a separate isolated Science UI/published-artifact verification note.

--- a/test/test_proxy_auth.py
+++ b/test/test_proxy_auth.py
@@ -67,6 +67,11 @@ def _req(url, method="GET", body=None):
         return e.code, e.read()
 
 
+def _read(path):
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
 @unittest.skipUnless(loopback_available(), "env-blocked: loopback bind/connect not permitted")
 class ProxyAuth(unittest.TestCase):
     @classmethod
@@ -426,6 +431,9 @@ class ProxyOpenAICustomForcedModelList(unittest.TestCase):
         self.assertEqual(body["first_id"], "claude-opus-4-8")
         self.assertEqual(body["last_id"], "claude-opus-4-8")
         self.assertEqual(self.hits, [], "formal proxy should not expose raw non-claude IDs")
+        log = _read(self.logf)
+        self.assertIn("GET /v1/models -> openai-custom(force 借壳): glm-4.5", log)
+        self.assertNotIn("fake-openai-key", log)
 
 
 @unittest.skipUnless(loopback_available(), "env-blocked: loopback bind/connect not permitted")
@@ -471,6 +479,7 @@ class ProxyOpenAIResponses(unittest.TestCase):
         self.assertNotIn("/up/v1/chat/completions", self.hits)
 
     def test_models_returns_claude_shell_for_science_selector(self):
+        self.hits.clear()
         s, b = _req(f"{self.base}/{SEC}/v1/models")
         self.assertEqual(s, 200, b[:160])
         body = json.loads(b)
@@ -481,6 +490,10 @@ class ProxyOpenAIResponses(unittest.TestCase):
             "supports_tools": None,
             "created_at": "2026-01-01T00:00:00Z",
         }])
+        self.assertEqual(self.hits, [], "formal proxy should not expose raw non-claude IDs")
+        log = _read(self.logf)
+        self.assertIn("GET /v1/models -> openai-responses(force 借壳): gpt-5.2", log)
+        self.assertNotIn("fake-openai-key", log)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Strengthen #26 proxy selector evidence for formal custom OpenAI and OpenAI Responses profiles.
- Assert force-mode /v1/models returns a single Science-visible claude-opus-4-8 shell with the configured model in display_name.
- Record the local isolated proxy/mock evidence and keep real Science UI, real account state, published DMG, signing/notarization, and official hosted capabilities out of scope.

## Verification
- git diff --check
- python3 -m unittest test.test_proxy_units test.test_proxy_auth -v
- PATH="/Users/superjj/.cargo/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/opt/homebrew/bin:/Users/superjj/.codex/tmp/arg0/codex-arg0vMiPU4:/Users/superjj/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/superjj/.local/bin:/Applications/Obsidian.app/Contents/MacOS:/Applications/Codex.app/Contents/Resources:/Applications/Obsidian.app/Contents/MacOS" cargo test --manifest-path desktop/src-tauri/Cargo.toml model_discovery
- PATH="/Users/superjj/.cargo/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/opt/homebrew/bin:/Users/superjj/.codex/tmp/arg0/codex-arg0vMiPU4:/Users/superjj/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/superjj/.local/bin:/Applications/Obsidian.app/Contents/MacOS:/Applications/Codex.app/Contents/Resources:/Applications/Obsidian.app/Contents/MacOS" cargo test --manifest-path desktop/src-tauri/Cargo.toml provider
- PATH="/Users/superjj/.cargo/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/opt/homebrew/bin:/Users/superjj/.codex/tmp/arg0/codex-arg0vMiPU4:/Users/superjj/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/superjj/.local/bin:/Applications/Obsidian.app/Contents/MacOS:/Applications/Codex.app/Contents/Resources:/Applications/Obsidian.app/Contents/MacOS" cargo test --manifest-path desktop/src-tauri/Cargo.toml profile
- bash test/run_all.sh --require-release-ready

## Review gates
- Proxy/test subagent: no blocking findings.
- Rust/runtime subagent: no blocking findings.
- Issue/docs closeout subagent: link issue fixed; conservative boundary passed.

## Boundaries
This PR does not claim real Science UI E2E, real Claude account state, real ~/.claude-science, published v0.3.6 artifact parity, DMG signing/notarization, or official hosted MCP/Directory/remote skill verification.