### PR TITLE
feat: surface science auth diagnostics

### DIFF
--- a/catalog/capabilities.v1.json
+++ b/catalog/capabilities.v1.json
@@ -325,6 +325,25 @@
       "tests": []
     },
     {
+      "id": "science.auth.refresh-hardcoded-0_1_15",
+      "scope": "science_version",
+      "match": {
+        "version": "0.1.15-dev.20260701.t220242.shaaa553de",
+        "auth_refresh": "api.anthropic.com/oauth/token"
+      },
+      "status": "limited",
+      "action": "diagnose",
+      "reason": "Issue #15 reports that this Science build may refresh OAuth via hardcoded api.anthropic.com/oauth/token outside ANTHROPIC_BASE_URL; virtual OAuth can then be treated as logged-out. CSSwitch surfaces this as a version/auth boundary, not as real-account success.",
+      "evidence": [
+        "https://github.com/SuperJJ007/CSSwitch/issues/15",
+        "docs/known-issues.md:37",
+        "findings/switching-organization-hang.md:16"
+      ],
+      "tests": [
+        "test.test_capability_catalog.CapabilityCatalogSchema.test_rule_ids_are_unique_and_key_rules_exist"
+      ]
+    },
+    {
       "id": "science.auth.virtual-oauth-scope-boundary",
       "scope": "science_version",
       "match": {

--- a/desktop/src-tauri/src/commands/runtime.rs
+++ b/desktop/src-tauri/src/commands/runtime.rs
@@ -6,7 +6,10 @@ use serde_json::json;
 use tauri::State;
 
 use crate::runtime::capability_catalog::diagnostics_for_profile;
-use crate::runtime::diagnostics::{build_status_response, status_lights, StatusProbeInput};
+use crate::runtime::diagnostics::{
+    build_status_response, science_diagnostics, status_lights, ScienceDiagnosticsInput,
+    StatusProbeInput,
+};
 use crate::runtime::operation::{self, OperationKind, OperationStage, OperationTrace};
 use crate::runtime::profile::profile_capabilities;
 use crate::runtime::provider::{
@@ -365,12 +368,15 @@ pub(crate) fn status(state: State<'_, SharedAppState>) -> serde_json::Value {
         )
     };
     let uhost = upstream_host(&adapter, &base_url);
+    let proxy_ok = !secret.is_empty()
+        && proc::http_health(pport, Some(&secret), operation::STATUS_HEALTH_TIMEOUT_MS);
+    let sandbox_ok = proc::http_health(sport, None, operation::STATUS_HEALTH_TIMEOUT_MS);
+    let upstream_ok = !uhost.is_empty()
+        && proc::tcp_reachable(&uhost, 443, operation::STATUS_UPSTREAM_TIMEOUT_MS);
     let lights = status_lights(StatusProbeInput {
-        proxy_ok: !secret.is_empty()
-            && proc::http_health(pport, Some(&secret), operation::STATUS_HEALTH_TIMEOUT_MS),
-        sandbox_ok: proc::http_health(sport, None, operation::STATUS_HEALTH_TIMEOUT_MS),
-        upstream_ok: !uhost.is_empty()
-            && proc::tcp_reachable(&uhost, 443, operation::STATUS_UPSTREAM_TIMEOUT_MS),
+        proxy_ok,
+        sandbox_ok,
+        upstream_ok,
     });
     let shim_mode = current_shim_mode_for_adapter(&adapter);
     build_status_response(
@@ -379,6 +385,10 @@ pub(crate) fn status(state: State<'_, SharedAppState>) -> serde_json::Value {
         gateway_kind_for_adapter(&adapter),
         shim_mode,
         diagnostics_for_profile(catalog_profile.as_ref(), shim_mode),
+        science_diagnostics(ScienceDiagnosticsInput {
+            sandbox_port: sport,
+            sandbox_ok,
+        }),
     )
 }
 

--- a/desktop/src-tauri/src/runtime/capability_catalog.rs
+++ b/desktop/src-tauri/src/runtime/capability_catalog.rs
@@ -219,6 +219,8 @@ fn boundary_rule_ids() -> &'static [&'static str] {
         "mcp.streamable-http.external-bio",
         "mcp.directory-connectors.virtual-login",
         "skill.remote-official.virtual-login-boundary",
+        "science.version.0_1_15_dev.route-diff",
+        "science.auth.refresh-hardcoded-0_1_15",
         "science.auth.virtual-oauth-scope-boundary",
         "transport.connect.anthropic-fastfail-401",
         "transport.connect.non-anthropic-direct-tunnel",
@@ -327,6 +329,7 @@ mod tests {
 
         let boundaries = ids(&v, "boundary_rules");
         assert!(boundaries.contains(&"mcp.hosted-anthropic.hcls-boundary".to_string()));
+        assert!(boundaries.contains(&"science.auth.refresh-hardcoded-0_1_15".to_string()));
         assert!(boundaries.contains(&"transport.upstream-proxy.planned-for-http-mcp".to_string()));
     }
 

--- a/desktop/src-tauri/src/runtime/diagnostics.rs
+++ b/desktop/src-tauri/src/runtime/diagnostics.rs
@@ -6,6 +6,11 @@ pub(crate) struct StatusProbeInput {
     pub(crate) upstream_ok: bool,
 }
 
+pub(crate) struct ScienceDiagnosticsInput {
+    pub(crate) sandbox_port: u16,
+    pub(crate) sandbox_ok: bool,
+}
+
 #[derive(Clone, Copy)]
 pub(crate) struct StatusLights {
     pub(crate) proxy: &'static str,
@@ -30,12 +35,40 @@ pub(crate) fn status_lights(input: StatusProbeInput) -> StatusLights {
     }
 }
 
+pub(crate) fn science_diagnostics(input: ScienceDiagnosticsInput) -> serde_json::Value {
+    json!({
+        "schema_version": 1,
+        "sandbox": {
+            "port": input.sandbox_port,
+            "health": light(input.sandbox_ok),
+        },
+        "auth": {
+            "mode": "virtual_oauth",
+            "real_account_verified": false,
+            "real_home_verified": false,
+            "known_boundary_rule_ids": [
+                "science.auth.virtual-oauth-scope-boundary",
+                "science.auth.refresh-hardcoded-0_1_15",
+            ],
+        },
+        "version": {
+            "status_probe": "not_run_in_status_poll",
+            "known_rule_ids": [
+                "science.version.0_1_15_dev.route-diff",
+                "science.auth.refresh-hardcoded-0_1_15",
+            ],
+            "note": "status() does not run claude-science binary/version probes; use isolated HOME and non-8765 ports before making Science-version or real-account claims.",
+        },
+    })
+}
+
 pub(crate) fn build_status_response(
     lights: StatusLights,
     active_profile: serde_json::Value,
     gateway_kind: &str,
     shim_mode: &str,
     catalog: serde_json::Value,
+    science: serde_json::Value,
 ) -> serde_json::Value {
     json!({
         "proxy": lights.proxy,
@@ -47,13 +80,17 @@ pub(crate) fn build_status_response(
             "shim_mode": shim_mode,
         },
         "catalog": catalog,
+        "science": science,
         "last_error": null,
     })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{build_status_response, status_lights, StatusProbeInput};
+    use super::{
+        build_status_response, science_diagnostics, status_lights, ScienceDiagnosticsInput,
+        StatusProbeInput,
+    };
     use serde_json::json;
 
     #[test]
@@ -101,6 +138,10 @@ mod tests {
                 "active_rules": [],
                 "boundary_rules": [],
             }),
+            science_diagnostics(ScienceDiagnosticsInput {
+                sandbox_port: 8990,
+                sandbox_ok: false,
+            }),
         );
         assert_eq!(v["proxy"], "green");
         assert_eq!(v["sandbox"], "amber");
@@ -109,6 +150,14 @@ mod tests {
         assert_eq!(v["runtime"]["gateway_kind"], "python");
         assert_eq!(v["runtime"]["shim_mode"], "off");
         assert_eq!(v["catalog"]["schema_version"], 1);
+        assert_eq!(v["science"]["schema_version"], 1);
+        assert_eq!(v["science"]["sandbox"]["port"], 8990);
+        assert_eq!(v["science"]["sandbox"]["health"], "amber");
+        assert_eq!(v["science"]["auth"]["real_account_verified"], false);
+        assert_eq!(
+            v["science"]["version"]["known_rule_ids"][1],
+            "science.auth.refresh-hardcoded-0_1_15"
+        );
         assert!(v["last_error"].is_null());
     }
 }

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -34,6 +34,7 @@
 - **当前本机安装版**：`/Applications/Claude Science.app` 仍是 `0.1.0-dev.20260630.t212931.sha2bc1ac8`。
 - **本地缓存证据版**：`.science-binaries/README.md` 记录过 `0.1.15-dev.20260701.t220242.shaaa553de`；该缓存只作为本地证据，不随公开包发布。本轮未读取、未复制、未修改真实 `~/.claude-science`。
 - **route diff 新增面**：`/api/auth/nonce`、`/api/auth/` 可能影响虚拟 OAuth / auth status；`/api/conda/conda-remote`、`/api/pypi/pypi-remote/simple`、conda mirror preference/probe 可能影响沙箱包源代理；`/api/frames/:id/token-series`、`/api/skills/:name/resync` 可能影响诊断或技能同步行为。
+- **2026-07-09 追加（#15 auth refresh / logged-out）：** catalog/status diagnostics 已新增 `science.auth.refresh-hardcoded-0_1_15` 边界，用于解释 `0.1.15-dev.20260701.t220242.shaaa553de` 可能通过硬编码 `api.anthropic.com/oauth/token` 刷新 OAuth、从而把虚拟 OAuth 判为 logged-out 的版本风险。`status().science` 只暴露沙箱健康、虚拟 OAuth 边界和“status 轮询不跑二进制版本探测”的说明；这不是修复真实账号态，也不等于真实 HOME、GUI E2E、published DMG 或 live provider E2E 验证。
 - **下一步**：在 `0.1.15-dev` 二进制可控时，用隔离 HOME + 非 `8765` 端口复跑虚拟 OAuth、沙箱启动、包源代理相关最小路径；不要从当前 `0.1.0-dev` 实测外推兼容结论。
 
 ## 3. ✅ 运行中再点主按钮的幂等分派（已随 v0.2.0 发布，已毕业）

--- a/test/test_capability_catalog.py
+++ b/test/test_capability_catalog.py
@@ -66,6 +66,7 @@ REQUIRED_RULE_IDS = {
     "tool.dashscope.responses.web_search-drop",
     "mcp.hosted-anthropic.hcls-boundary",
     "science.version.0_1_15_dev.route-diff",
+    "science.auth.refresh-hardcoded-0_1_15",
     "transport.connect.anthropic-fastfail-401",
 }
 


### PR DESCRIPTION
## Summary
- add a catalog rule for #15 / Claude Science 0.1.15-dev hardcoded OAuth refresh risk
- include Science auth/version boundary rules in status catalog diagnostics
- add `status().science` diagnostics for sandbox health, virtual OAuth boundaries, and version-probe caveats
- update known-issues with conservative wording

## Boundaries
- does not change proxy behavior or outbound payloads
- does not mock OAuth refresh, DNS, hosts, or real account state
- does not read or modify real `~/.claude-science`
- does not claim GUI E2E, published DMG, signing/notarization, or live provider E2E verification

## Validation
- python3 -m unittest test.test_capability_catalog -v
- cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --check
- cargo test --manifest-path desktop/src-tauri/Cargo.toml diagnostics
- cargo test --manifest-path desktop/src-tauri/Cargo.toml capability_catalog
- cargo test --manifest-path desktop/src-tauri/Cargo.toml science
- bash test/run_all.sh --require-release-ready
- git diff --check

## Review gate
- read-only subagent review found no blocking findings
- one P3 evidence line reference was tightened before commit
