### PR TITLE
Issue #12: surface proxy-unhealthy recovery diagnostics

### DIFF
--- a/desktop/src-tauri/src/commands/runtime.rs
+++ b/desktop/src-tauri/src/commands/runtime.rs
@@ -7,8 +7,8 @@ use tauri::State;
 
 use crate::runtime::capability_catalog::diagnostics_for_profile;
 use crate::runtime::diagnostics::{
-    build_status_response, science_diagnostics, status_lights, ScienceDiagnosticsInput,
-    StatusProbeInput,
+    build_status_response, proxy_status_last_error, science_diagnostics, status_lights,
+    ScienceDiagnosticsInput, StatusProbeInput,
 };
 use crate::runtime::operation::{self, OperationKind, OperationStage, OperationTrace};
 use crate::runtime::profile::profile_capabilities;
@@ -399,6 +399,7 @@ pub(crate) fn status(state: State<'_, SharedAppState>) -> serde_json::Value {
     let upstream = upstream_endpoint(&adapter, &base_url);
     let proxy_ok = !secret.is_empty()
         && proc::http_health(pport, Some(&secret), operation::STATUS_HEALTH_TIMEOUT_MS);
+    let last_error = proxy_status_last_error(!secret.is_empty(), proxy_ok, pport);
     let sandbox_ok = proc::http_health(sport, None, operation::STATUS_HEALTH_TIMEOUT_MS);
     let upstream_ok = upstream
         .as_ref()
@@ -420,7 +421,7 @@ pub(crate) fn status(state: State<'_, SharedAppState>) -> serde_json::Value {
             sandbox_port: sport,
             sandbox_ok,
         }),
-        None,
+        last_error,
     )
 }
 

--- a/desktop/src-tauri/src/runtime/diagnostics.rs
+++ b/desktop/src-tauri/src/runtime/diagnostics.rs
@@ -62,6 +62,22 @@ pub(crate) fn science_diagnostics(input: ScienceDiagnosticsInput) -> serde_json:
     })
 }
 
+pub(crate) fn proxy_status_last_error(
+    secret_present: bool,
+    proxy_ok: bool,
+    proxy_port: u16,
+) -> Option<serde_json::Value> {
+    if secret_present && !proxy_ok {
+        Some(json!({
+            "type": "proxy_unhealthy",
+            "message": "代理进程不可达或已退出，请点击「一键开始」或「启动代理」恢复。",
+            "port": proxy_port,
+        }))
+    } else {
+        None
+    }
+}
+
 pub(crate) fn build_status_response(
     lights: StatusLights,
     active_profile: serde_json::Value,
@@ -89,8 +105,8 @@ pub(crate) fn build_status_response(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_status_response, science_diagnostics, status_lights, ScienceDiagnosticsInput,
-        StatusProbeInput,
+        build_status_response, proxy_status_last_error, science_diagnostics, status_lights,
+        ScienceDiagnosticsInput, StatusProbeInput,
     };
     use serde_json::json;
 
@@ -186,5 +202,44 @@ mod tests {
         );
         assert_eq!(v["last_error"]["type"], "config_error");
         assert_eq!(v["last_error"]["message"], "config unreadable");
+    }
+
+    #[test]
+    fn proxy_status_last_error_only_when_secreted_proxy_is_unhealthy() {
+        assert!(proxy_status_last_error(false, false, 18991).is_none());
+        assert!(proxy_status_last_error(true, true, 18991).is_none());
+
+        let err = proxy_status_last_error(true, false, 18991).unwrap();
+        assert_eq!(err["type"], "proxy_unhealthy");
+        assert_eq!(err["port"], 18991);
+        assert!(
+            err["message"].as_str().unwrap().contains("代理进程不可达"),
+            "should not imply an API key failure: {err}"
+        );
+    }
+
+    #[test]
+    fn status_response_can_surface_proxy_unhealthy_last_error() {
+        let v = build_status_response(
+            status_lights(StatusProbeInput {
+                proxy_ok: false,
+                sandbox_ok: true,
+                upstream_ok: true,
+            }),
+            serde_json::Value::Null,
+            "python",
+            "off",
+            json!({"schema_version": 1}),
+            science_diagnostics(ScienceDiagnosticsInput {
+                sandbox_port: 8990,
+                sandbox_ok: true,
+            }),
+            proxy_status_last_error(true, false, 18991),
+        );
+        assert_eq!(v["proxy"], "amber");
+        assert_eq!(v["sandbox"], "green");
+        assert_eq!(v["upstream"], "green");
+        assert_eq!(v["last_error"]["type"], "proxy_unhealthy");
+        assert_eq!(v["last_error"]["port"], 18991);
     }
 }

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -121,6 +121,7 @@ let statusTimer = null;
 let busy = false;
 let busyOp = null;
 let busyMsgTimers = [];
+let statusRecoveryMsg = "";
 let mode = "proxy"; // "proxy" 第三方 | "official" 官方
 // 当前配置快照（get_config 结果）。全 key 绝不在此，只有掩码。
 let configState = { profiles: [], templates: [], active_id: "", proxy_port: 18991, sandbox_port: 8990 };
@@ -187,6 +188,7 @@ const MODEL_HINT = {
   follow: "留空＝跟随 Science 选择器（保留 opus/haiku 各档）；选一个＝固定用于所有请求。",
   fixed: "该来源需选一个模型（不认 claude-*，将用于所有请求含后台任务）。",
 };
+const PROXY_UNHEALTHY_MSG = "代理进程不可达或已退出，请点击「一键开始」或「启动代理」恢复。";
 
 // 据能力渲染模型字段。native：只读信息 + 隐藏下拉/获取按钮，但把既有 model 留在隐藏下拉里
 // （避免保存时被空值覆盖，守「零运行语义变化」）；relay：走下拉。
@@ -234,6 +236,28 @@ function setMsg(text, kind) {
 function setLight(el, s) {
   const cls = { green: "g", amber: "a", red: "r" }[s] || "a";
   el.className = "lt " + cls;
+}
+
+function proxyRecoveryMessage(status) {
+  const err = status && status.last_error;
+  if (err && err.type === "proxy_unhealthy") return err.message || PROXY_UNHEALTHY_MSG;
+  return "";
+}
+
+function setStatusRecoveryMsg(text) {
+  if (busy) return;
+  const current = els.msg.textContent || "";
+  if (text) {
+    if (!current || current === statusRecoveryMsg) {
+      setMsg(text, "err");
+      statusRecoveryMsg = text;
+    }
+    return;
+  }
+  if (statusRecoveryMsg && current === statusRecoveryMsg) {
+    setMsg("");
+  }
+  statusRecoveryMsg = "";
 }
 
 function clearBusyMsgTimers() {
@@ -1040,6 +1064,7 @@ async function refreshStatus() {
     setLight(els.ltSandbox, s.sandbox);
     setLight(els.ltUpstream, s.upstream);
     els.brandDot.className = "dot" + (s.proxy === "green" ? "" : " amber");
+    setStatusRecoveryMsg(proxyRecoveryMessage(s));
   } catch (e) {
     [els.ltProxy, els.ltSandbox, els.ltUpstream].forEach((l) => setLight(l, "amber"));
   }


### PR DESCRIPTION
## Summary

This is the minimal diagnostics slice for issue #12. It makes CSSwitch surface a typed proxy recovery state when the local proxy has a saved secret but its authenticated health check fails.

Supported by this PR:
- `status().last_error.type = "proxy_unhealthy"` when the local proxy is dead/unhealthy after a proxy secret exists.
- The UI shows a manual recovery prompt asking the user to click one-click start or start proxy.
- Existing status lights stay compatible: proxy remains `amber` rather than introducing a new light state.

Not supported or claimed by this PR:
- No automatic supervisor/restart loop.
- No launchd or background/native Claude Science app launch work.
- No GUI E2E, live provider, true HOME, real account, DMG parity, Developer ID signing, notarization, or Gatekeeper verification.
- No #11 upstream proxy / Streamable HTTP MCP transport work.
- No #3 background-resident launch behavior.
- No python-ectomy or Python proxy protocol changes.

This PR should not resolve issue 12 by itself. Resolving issue 12 still requires a follow-up manual recovery proof showing that after the proxy is killed, the user can recover to a working green state via one-click start/start proxy under isolated test conditions.

## Validation

- Read-only sub-agent review passed after fixing one frontend polling feedback issue.
- `PATH="/Users/superjj/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" cargo test runtime::diagnostics::tests:: --lib`
- `node --check desktop/src/main.js`
- `git diff --check`
- `PYTHONDONTWRITEBYTECODE=1 bash test/run_all.sh --require-release-ready`

Local gate is green. GitHub checks are not claimed here unless reported by GitHub.
