### PR TITLE
Implement native entry and resident boot flow

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -759,6 +759,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
 ]
 
 [[package]]
@@ -3550,6 +3551,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8f29386f5e9fdc699182388a33ee80a56de436d91b67459e86afef426282af"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4594,6 +4610,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4625,11 +4650,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4663,6 +4705,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4673,6 +4721,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4687,10 +4741,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4705,6 +4771,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4715,6 +4787,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4729,6 +4807,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4739,6 +4823,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
+tauri-plugin-single-instance = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # 虚拟 OAuth 伪造器（Rust 原生，去 node 依赖 —— 见 src/oauth_forge.rs）。

--- a/desktop/src-tauri/src/commands/profiles.rs
+++ b/desktop/src-tauri/src/commands/profiles.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use serde_json::json;
 use tauri::State;
 
@@ -11,7 +13,7 @@ use crate::runtime::provider::{
     adapter_for_profile, reject_openai_custom_anthropic_base, relay_missing_base_url,
     relay_missing_model,
 };
-use crate::{config, lock, run_blocking, SharedAppState, SharedLifecycle};
+use crate::{config, lifecycle, lock, run_blocking, SharedAppState, SharedLifecycle};
 
 #[tauri::command]
 pub(crate) fn get_config() -> Result<serde_json::Value, String> {
@@ -66,19 +68,12 @@ pub(crate) fn clear_profile_key(
     lifecycle: State<'_, SharedLifecycle>,
     id: String,
 ) -> Result<(), String> {
-    lifecycle.with_serialized(|| {
-        let dir = config::default_dir();
-        let was_active = config::load_from(&dir)
-            .map(|c| c.active_id == id)
-            .unwrap_or(false);
-        clear_profile_key_inner(&dir, &id)?;
-        if was_active {
-            lifecycle.bump_generation();
-            let mut st = lock(state.inner());
-            st.stop_proxy();
-        }
-        Ok(())
-    })
+    clear_profile_key_cmd(
+        &config::default_dir(),
+        state.inner(),
+        lifecycle.as_ref(),
+        &id,
+    )
 }
 
 /// 删 profile：经串行器；删的是【生效】profile → active 置空（inner 内）+ bump + 停代理。
@@ -88,15 +83,48 @@ pub(crate) fn delete_profile(
     lifecycle: State<'_, SharedLifecycle>,
     id: String,
 ) -> Result<(), String> {
+    delete_profile_cmd(
+        &config::default_dir(),
+        state.inner(),
+        lifecycle.as_ref(),
+        &id,
+    )
+}
+
+fn clear_profile_key_cmd(
+    dir: &Path,
+    state: &SharedAppState,
+    lifecycle: &lifecycle::Lifecycle,
+    id: &str,
+) -> Result<(), String> {
     lifecycle.with_serialized(|| {
-        let dir = config::default_dir();
-        let was_active = config::load_from(&dir)
+        let was_active = config::load_from(dir)
             .map(|c| c.active_id == id)
             .unwrap_or(false);
-        delete_profile_inner(&dir, &id)?;
+        clear_profile_key_inner(dir, id)?;
         if was_active {
             lifecycle.bump_generation();
-            let mut st = lock(state.inner());
+            let mut st = lock(state);
+            st.stop_proxy();
+        }
+        Ok(())
+    })
+}
+
+fn delete_profile_cmd(
+    dir: &Path,
+    state: &SharedAppState,
+    lifecycle: &lifecycle::Lifecycle,
+    id: &str,
+) -> Result<(), String> {
+    lifecycle.with_serialized(|| {
+        let was_active = config::load_from(dir)
+            .map(|c| c.active_id == id)
+            .unwrap_or(false);
+        delete_profile_inner(dir, id)?;
+        if was_active {
+            lifecycle.bump_generation();
+            let mut st = lock(state);
             st.stop_proxy();
         }
         Ok(())
@@ -222,4 +250,124 @@ fn set_active_profile_inner_cmd(
     lifecycle.with_serialized(|| {
         set_active_profile_txn(&app, &state, lifecycle.as_ref(), &id, skip_verify, None)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{clear_profile_key_cmd, delete_profile_cmd};
+    use crate::{
+        config::{self, Config, Profile},
+        lifecycle, lock, AppState, SharedAppState,
+    };
+    use std::{
+        fs,
+        sync::{Arc, Mutex},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn tmpdir(name: &str) -> std::path::PathBuf {
+        let n = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("csswitch-{name}-{n}"))
+    }
+
+    fn profile(id: &str, key: &str) -> Profile {
+        Profile {
+            id: id.into(),
+            name: id.into(),
+            template_id: "deepseek".into(),
+            category: "cn_official".into(),
+            api_format: "anthropic".into(),
+            base_url: "https://api.deepseek.com/anthropic".into(),
+            api_key: key.into(),
+            ..Default::default()
+        }
+    }
+
+    fn state_with_proxy_identity() -> SharedAppState {
+        Arc::new(Mutex::new(AppState {
+            secret: "runtime-secret".into(),
+            provider: "deepseek".into(),
+            key_fp: 42,
+            ..AppState::default()
+        }))
+    }
+
+    #[test]
+    fn clear_active_profile_key_stops_runtime_proxy_identity() {
+        let dir = tmpdir("clear-active-key");
+        let cfg = Config {
+            profiles: vec![profile("active", "sk-active")],
+            active_id: "active".into(),
+            ..Default::default()
+        };
+        config::save_to(&dir, &cfg).unwrap();
+        let state = state_with_proxy_identity();
+        let lifecycle = lifecycle::Lifecycle::new();
+        let before = lifecycle.current_generation();
+
+        clear_profile_key_cmd(&dir, &state, &lifecycle, "active").unwrap();
+
+        let after = config::load_from(&dir).unwrap();
+        assert_eq!(after.profile_by_id("active").unwrap().api_key, "");
+        assert!(lifecycle.current_generation() > before);
+        let st = lock(&state);
+        assert!(st.secret.is_empty());
+        assert!(st.provider.is_empty());
+        assert_eq!(st.key_fp, 0);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn clear_non_active_profile_key_leaves_runtime_proxy_identity() {
+        let dir = tmpdir("clear-non-active-key");
+        let cfg = Config {
+            profiles: vec![profile("active", "sk-active"), profile("other", "sk-other")],
+            active_id: "active".into(),
+            ..Default::default()
+        };
+        config::save_to(&dir, &cfg).unwrap();
+        let state = state_with_proxy_identity();
+        let lifecycle = lifecycle::Lifecycle::new();
+        let before = lifecycle.current_generation();
+
+        clear_profile_key_cmd(&dir, &state, &lifecycle, "other").unwrap();
+
+        let after = config::load_from(&dir).unwrap();
+        assert_eq!(after.profile_by_id("other").unwrap().api_key, "");
+        assert_eq!(lifecycle.current_generation(), before);
+        let st = lock(&state);
+        assert_eq!(st.secret, "runtime-secret");
+        assert_eq!(st.provider, "deepseek");
+        assert_eq!(st.key_fp, 42);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn delete_active_profile_stops_runtime_proxy_identity() {
+        let dir = tmpdir("delete-active-profile");
+        let cfg = Config {
+            profiles: vec![profile("active", "sk-active")],
+            active_id: "active".into(),
+            ..Default::default()
+        };
+        config::save_to(&dir, &cfg).unwrap();
+        let state = state_with_proxy_identity();
+        let lifecycle = lifecycle::Lifecycle::new();
+        let before = lifecycle.current_generation();
+
+        delete_profile_cmd(&dir, &state, &lifecycle, "active").unwrap();
+
+        let after = config::load_from(&dir).unwrap();
+        assert!(after.active_id.is_empty());
+        assert!(after.profile_by_id("active").is_none());
+        assert!(lifecycle.current_generation() > before);
+        let st = lock(&state);
+        assert!(st.secret.is_empty());
+        assert!(st.provider.is_empty());
+        assert_eq!(st.key_fp, 0);
+        let _ = fs::remove_dir_all(&dir);
+    }
 }

--- a/desktop/src-tauri/src/commands/runtime.rs
+++ b/desktop/src-tauri/src/commands/runtime.rs
@@ -335,7 +335,7 @@ pub(crate) async fn one_click_login(
     run_blocking(move || one_click_login_cmd(app, state, lifecycle)).await
 }
 
-fn one_click_login_cmd(
+pub(crate) fn one_click_login_cmd(
     app: tauri::AppHandle,
     state: SharedAppState,
     lifecycle: SharedLifecycle,
@@ -426,6 +426,11 @@ pub(crate) fn status(state: State<'_, SharedAppState>) -> serde_json::Value {
 }
 
 #[tauri::command]
+pub(crate) fn boot_error(state: State<'_, SharedAppState>) -> Option<String> {
+    lock(state.inner()).boot_error.clone()
+}
+
+#[tauri::command]
 pub(crate) fn open_url(state: State<'_, SharedAppState>) -> Result<(), String> {
     let url = { lock(state.inner()).sandbox_url.clone() };
     let url = url.ok_or("还没有沙箱 URL，请先「一键开始」。")?;
@@ -433,15 +438,8 @@ pub(crate) fn open_url(state: State<'_, SharedAppState>) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub(crate) fn quit_app(
-    app: tauri::AppHandle,
-    state: State<'_, SharedAppState>,
-) -> Result<(), String> {
-    // 默认：退 app 停代理、保留沙箱运行（spec §5.1）。
-    {
-        let mut st = lock(state.inner());
-        st.stop_proxy();
-    }
+pub(crate) fn quit_app(app: tauri::AppHandle) -> Result<(), String> {
+    // 显式退出统一交给 RunEvent::ExitRequested 清理，避免多个退出入口各自停代理。
     app.exit(0);
     Ok(())
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -24,9 +24,39 @@ mod templates;
 use std::process::Child;
 use std::sync::{Arc, Mutex};
 
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 use runtime::system::kill_child;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum LaunchPath {
+    ShowPanel,
+    OpenOfficial,
+    BootScience,
+}
+
+fn decide_launch(cfg: &config::Config) -> LaunchPath {
+    if cfg.mode == "official" {
+        return LaunchPath::OpenOfficial;
+    }
+    match cfg.active_profile() {
+        Some(p) if !p.api_key.trim().is_empty() => LaunchPath::BootScience,
+        _ => LaunchPath::ShowPanel,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum BootState {
+    #[default]
+    Idle,
+    Starting,
+    Ready,
+    Failed,
+}
+
+fn should_begin_boot(state: BootState) -> bool {
+    matches!(state, BootState::Idle | BootState::Failed)
+}
 
 #[derive(Default)]
 pub(crate) struct AppState {
@@ -41,6 +71,8 @@ pub(crate) struct AppState {
     pub(crate) sandbox: Option<Child>,
     pub(crate) sandbox_port: u16,
     pub(crate) sandbox_url: Option<String>,
+    boot: BootState,
+    pub(crate) boot_error: Option<String>,
 }
 
 impl AppState {
@@ -75,11 +107,110 @@ where
         .map_err(|e| format!("后台任务失败：{e}"))?
 }
 
+fn show_main_window<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    if let Some(win) = app.get_webview_window("main") {
+        let _ = win.show();
+        let _ = win.set_focus();
+    }
+}
+
+fn install_menu(app: &tauri::App) -> tauri::Result<()> {
+    use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
+
+    let preferences = MenuItemBuilder::with_id("preferences", "偏好设置...")
+        .accelerator("CmdOrCtrl+,")
+        .build(app)?;
+    let app_menu = SubmenuBuilder::new(app, "CSSwitch")
+        .item(&preferences)
+        .separator()
+        .quit()
+        .build()?;
+    let menu = MenuBuilder::new(app).item(&app_menu).build()?;
+    app.set_menu(menu)?;
+    app.on_menu_event(|app, event| {
+        if event.id().as_ref() == "preferences" {
+            show_main_window(app);
+        }
+    });
+    Ok(())
+}
+
+fn cleanup_for_exit<R: tauri::Runtime>(app: &tauri::AppHandle<R>) {
+    let state = app.state::<SharedAppState>();
+    let mut st = lock(state.inner());
+    st.stop_proxy();
+}
+
+fn mark_boot_failed<R: tauri::Runtime>(app: &tauri::AppHandle<R>, error: String) {
+    let state = app.state::<SharedAppState>();
+    {
+        let mut st = lock(state.inner());
+        st.boot = BootState::Failed;
+        st.boot_error = Some(error.clone());
+    }
+    show_main_window(app);
+    let _ = app.emit("boot://failed", error);
+}
+
+fn run_boot_coordinator(app: tauri::AppHandle) {
+    {
+        let state = app.state::<SharedAppState>();
+        let mut st = lock(state.inner());
+        if !should_begin_boot(st.boot) {
+            show_main_window(&app);
+            return;
+        }
+        st.boot = BootState::Starting;
+    }
+
+    tauri::async_runtime::spawn_blocking(move || {
+        let cfg = match config::load_from(&config::default_dir()) {
+            Ok(cfg) => cfg,
+            Err(e) => {
+                mark_boot_failed(&app, format!("读取配置失败：{e}"));
+                return;
+            }
+        };
+        let state = app.state::<SharedAppState>();
+        match decide_launch(&cfg) {
+            LaunchPath::ShowPanel => {
+                let mut st = lock(state.inner());
+                st.boot = BootState::Idle;
+                st.boot_error = None;
+                show_main_window(&app);
+            }
+            LaunchPath::OpenOfficial => match commands::runtime::open_official() {
+                Ok(()) => {
+                    let mut st = lock(state.inner());
+                    st.boot = BootState::Idle;
+                    st.boot_error = None;
+                }
+                Err(e) => mark_boot_failed(&app, e),
+            },
+            LaunchPath::BootScience => {
+                let state_inner = state.inner().clone();
+                let lifecycle = app.state::<SharedLifecycle>().inner().clone();
+                match commands::runtime::one_click_login_cmd(app.clone(), state_inner, lifecycle) {
+                    Ok(_) => {
+                        let mut st = lock(state.inner());
+                        st.boot = BootState::Ready;
+                        st.boot_error = None;
+                    }
+                    Err(e) => mark_boot_failed(&app, e),
+                }
+            }
+        }
+    });
+}
+
 // ---------- 入口 ----------
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            run_boot_coordinator(app.clone());
+        }))
         .manage(Arc::new(Mutex::new(AppState::default())))
         .manage(Arc::new(lifecycle::Lifecycle::new()))
         .invoke_handler(tauri::generate_handler![
@@ -100,6 +231,7 @@ pub fn run() {
             commands::runtime::stop_all,
             commands::runtime::one_click_login,
             commands::runtime::status,
+            commands::runtime::boot_error,
             commands::runtime::open_url,
             commands::diagnostics::run_doctor,
             commands::diagnostics::app_version,
@@ -109,34 +241,40 @@ pub fn run() {
             commands::runtime::quit_app
         ])
         .setup(|app| {
-            // 正常桌面应用：进 Dock、走常规应用生命周期。窗口在 tauri.conf.json 里配了
-            // decorations + visible + center，启动即居中弹出、可拖动。托盘图标已移除。
+            install_menu(app)?;
 
             // 启动即触发一次 load：若是旧 v1 固定槽文件，这里完成 v1→v2 迁移 + 落盘 + 留 .v1.bak；
             // 悬空 active 归一化为空。迁移逻辑并入 config::load_from（不再单独跑 relay_presets）。
             let _ = config::load_from(&config::default_dir());
 
-            // 关窗即退出：与「退出」按钮一致 —— 停代理、清 secret，保留沙箱运行（spec §5.1）。
+            // 关窗隐藏配置面板，不销毁窗口、不停止后台链路。显式退出统一清理代理。
             if let Some(win) = app.get_webview_window("main") {
-                let handle = app.handle().clone();
+                let w = win.clone();
                 win.on_window_event(move |ev| {
-                    if let tauri::WindowEvent::CloseRequested { .. } = ev {
-                        let state = handle.state::<SharedAppState>();
-                        let mut st = lock(state.inner());
-                        st.stop_proxy();
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = ev {
+                        api.prevent_close();
+                        let _ = w.hide();
                     }
                 });
             }
+            run_boot_coordinator(app.handle().clone());
             Ok(())
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+
+    app.run(|app, event| {
+        if let tauri::RunEvent::ExitRequested { .. } = event {
+            cleanup_for_exit(app);
+        }
+    });
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::config::{Config, Profile};
     use crate::runtime::system::redact;
-    use crate::AppState;
+    use crate::{decide_launch, should_begin_boot, AppState, BootState, LaunchPath};
 
     #[test]
     fn app_state_clear_proxy_identity_removes_runtime_credentials() {
@@ -160,5 +298,62 @@ mod tests {
         );
         assert_eq!(redact("原样返回", ""), "原样返回");
         assert!(!redact("leak abcd1234 leak abcd1234", "abcd1234").contains("abcd1234"));
+    }
+
+    fn keyed_profile(id: &str, key: &str) -> Profile {
+        Profile {
+            id: id.into(),
+            name: id.into(),
+            template_id: "deepseek".into(),
+            category: "cn_official".into(),
+            api_format: "anthropic".into(),
+            api_key: key.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn decide_launch_uses_current_mode_and_active_profile_key() {
+        let official = Config {
+            mode: "official".into(),
+            ..Default::default()
+        };
+        assert_eq!(decide_launch(&official), LaunchPath::OpenOfficial);
+
+        let no_active = Config {
+            profiles: vec![keyed_profile("p1", "sk-present")],
+            active_id: String::new(),
+            ..Default::default()
+        };
+        assert_eq!(decide_launch(&no_active), LaunchPath::ShowPanel);
+
+        let active_without_key = Config {
+            profiles: vec![keyed_profile("p1", "")],
+            active_id: "p1".into(),
+            ..Default::default()
+        };
+        assert_eq!(decide_launch(&active_without_key), LaunchPath::ShowPanel);
+
+        let active_with_key = Config {
+            profiles: vec![keyed_profile("p1", "sk-present")],
+            active_id: "p1".into(),
+            ..Default::default()
+        };
+        assert_eq!(decide_launch(&active_with_key), LaunchPath::BootScience);
+
+        let dangling_active = Config {
+            profiles: vec![keyed_profile("p1", "sk-present")],
+            active_id: "missing".into(),
+            ..Default::default()
+        };
+        assert_eq!(decide_launch(&dangling_active), LaunchPath::ShowPanel);
+    }
+
+    #[test]
+    fn should_begin_boot_only_from_idle_or_failed() {
+        assert!(should_begin_boot(BootState::Idle));
+        assert!(should_begin_boot(BootState::Failed));
+        assert!(!should_begin_boot(BootState::Starting));
+        assert!(!should_begin_boot(BootState::Ready));
     }
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -35,7 +35,10 @@ enum LaunchPath {
     BootScience,
 }
 
-fn decide_launch(cfg: &config::Config) -> LaunchPath {
+fn decide_launch_with_auto_boot(cfg: &config::Config, auto_boot: bool) -> LaunchPath {
+    if !auto_boot {
+        return LaunchPath::ShowPanel;
+    }
     if cfg.mode == "official" {
         return LaunchPath::OpenOfficial;
     }
@@ -43,6 +46,14 @@ fn decide_launch(cfg: &config::Config) -> LaunchPath {
         Some(p) if !p.api_key.trim().is_empty() => LaunchPath::BootScience,
         _ => LaunchPath::ShowPanel,
     }
+}
+
+fn decide_launch(cfg: &config::Config) -> LaunchPath {
+    let auto_boot = std::env::var("CSSWITCH_AUTO_BOOT_ON_LAUNCH")
+        .ok()
+        .as_deref()
+        == Some("1");
+    decide_launch_with_auto_boot(cfg, auto_boot)
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -274,7 +285,7 @@ pub fn run() {
 mod tests {
     use crate::config::{Config, Profile};
     use crate::runtime::system::redact;
-    use crate::{decide_launch, should_begin_boot, AppState, BootState, LaunchPath};
+    use crate::{decide_launch_with_auto_boot, should_begin_boot, AppState, BootState, LaunchPath};
 
     #[test]
     fn app_state_clear_proxy_identity_removes_runtime_credentials() {
@@ -313,40 +324,68 @@ mod tests {
     }
 
     #[test]
-    fn decide_launch_uses_current_mode_and_active_profile_key() {
+    fn decide_launch_defaults_to_showing_panel() {
+        let active_with_key = Config {
+            profiles: vec![keyed_profile("p1", "sk-present")],
+            active_id: "p1".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            decide_launch_with_auto_boot(&active_with_key, false),
+            LaunchPath::ShowPanel
+        );
+    }
+
+    #[test]
+    fn decide_launch_auto_boot_uses_current_mode_and_active_profile_key() {
         let official = Config {
             mode: "official".into(),
             ..Default::default()
         };
-        assert_eq!(decide_launch(&official), LaunchPath::OpenOfficial);
+        assert_eq!(
+            decide_launch_with_auto_boot(&official, true),
+            LaunchPath::OpenOfficial
+        );
 
         let no_active = Config {
             profiles: vec![keyed_profile("p1", "sk-present")],
             active_id: String::new(),
             ..Default::default()
         };
-        assert_eq!(decide_launch(&no_active), LaunchPath::ShowPanel);
+        assert_eq!(
+            decide_launch_with_auto_boot(&no_active, true),
+            LaunchPath::ShowPanel
+        );
 
         let active_without_key = Config {
             profiles: vec![keyed_profile("p1", "")],
             active_id: "p1".into(),
             ..Default::default()
         };
-        assert_eq!(decide_launch(&active_without_key), LaunchPath::ShowPanel);
+        assert_eq!(
+            decide_launch_with_auto_boot(&active_without_key, true),
+            LaunchPath::ShowPanel
+        );
 
         let active_with_key = Config {
             profiles: vec![keyed_profile("p1", "sk-present")],
             active_id: "p1".into(),
             ..Default::default()
         };
-        assert_eq!(decide_launch(&active_with_key), LaunchPath::BootScience);
+        assert_eq!(
+            decide_launch_with_auto_boot(&active_with_key, true),
+            LaunchPath::BootScience
+        );
 
         let dangling_active = Config {
             profiles: vec![keyed_profile("p1", "sk-present")],
             active_id: "missing".into(),
             ..Default::default()
         };
-        assert_eq!(decide_launch(&dangling_active), LaunchPath::ShowPanel);
+        assert_eq!(
+            decide_launch_with_auto_boot(&dangling_active, true),
+            LaunchPath::ShowPanel
+        );
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -274,10 +274,10 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application");
 
-    app.run(|app, event| {
-        if let tauri::RunEvent::ExitRequested { .. } = event {
-            cleanup_for_exit(app);
-        }
+    app.run(|app, event| match event {
+        tauri::RunEvent::Reopen { .. } => show_main_window(app),
+        tauri::RunEvent::ExitRequested { .. } => cleanup_for_exit(app),
+        _ => {}
     });
 }
 

--- a/desktop/src-tauri/src/runtime/sandbox_session.rs
+++ b/desktop/src-tauri/src/runtime/sandbox_session.rs
@@ -2,7 +2,7 @@ use std::process::{Command, Stdio};
 use std::time::Duration;
 
 use serde_json::{json, Value};
-use tauri::Runtime;
+use tauri::{Manager, Runtime};
 
 use crate::runtime::operation::{
     self, OperationKind, OperationStage, OperationTrace, POLL_INTERVAL_MS,
@@ -18,6 +18,39 @@ fn stop_sandbox_state<R: Runtime>(
     st: &mut AppState,
 ) -> Result<(), String> {
     stop_sandbox(app, &mut st.sandbox, &mut st.sandbox_url)
+}
+
+fn open_science_surface<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+    url: &str,
+) -> Result<&'static str, String> {
+    if std::env::var("CSSWITCH_SCIENCE_WEBVIEW_SPIKE")
+        .ok()
+        .as_deref()
+        == Some("1")
+    {
+        if let Some(win) = app.get_webview_window("science") {
+            let _ = win.close();
+        }
+        let parsed = url
+            .parse()
+            .map_err(|e| format!("Science URL 解析失败：{e}"))?;
+        match tauri::WebviewWindowBuilder::new(app, "science", tauri::WebviewUrl::External(parsed))
+            .title("Claude Science")
+            .inner_size(1100.0, 800.0)
+            .build()
+        {
+            Ok(win) => {
+                let _ = win.set_focus();
+                return Ok("webview");
+            }
+            Err(_) => {
+                // Spike-only path: construction failure falls through to the existing browser surface.
+            }
+        }
+    }
+    open_in_browser(url)?;
+    Ok("browser")
 }
 
 /// One-click session startup: active proxy, virtual login, sandbox, browser.
@@ -50,8 +83,9 @@ pub(crate) fn one_click_login<R: Runtime>(
                 ProxyAction::Reused => "已在运行",
                 ProxyAction::Restarted => "已用新配置重启代理，Science 沿用不变",
             };
-            let msg = match open_in_browser(&url) {
-                Ok(()) => format!("{base}，已重新打开 Science。"),
+            let msg = match open_science_surface(&app, &url) {
+                Ok("webview") => format!("{base}，已重新打开 Science 窗口。"),
+                Ok(_) => format!("{base}，已重新打开 Science。"),
                 Err(_) => format!("{base}，服务已就绪，请手动打开：{url}"),
             };
             trace.finish(format!(
@@ -159,8 +193,9 @@ pub(crate) fn one_click_login<R: Runtime>(
         oauth_forge::LoginAction::Created => "已启动",
         _ => "沙箱已重新启动，沿用原有对话",
     };
-    let msg = match open_in_browser(&url) {
-        Ok(()) => format!("{started}。"),
+    let msg = match open_science_surface(&app, &url) {
+        Ok("webview") => format!("{started}，已打开 Science 窗口。"),
+        Ok(_) => format!("{started}。"),
         Err(_) => format!("{started}，服务已就绪，请手动打开：{url}"),
     };
     trace.stage(OperationStage::OpenBrowser, "done");

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
         "resizable": true,
         "decorations": true,
         "transparent": false,
-        "visible": true,
+        "visible": false,
         "center": true,
         "focus": true
       }

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -122,7 +122,10 @@ const els = {};
 let statusTimer = null;
 let busy = false;
 let busyOp = null;
+let activationInFlight = false;
+let activationOp = null;
 let busyMsgTimers = [];
+let doctorInFlight = false;
 let statusRecoveryMsg = "";
 let mode = "proxy"; // "proxy" 第三方 | "official" 官方
 // 当前配置快照（get_config 结果）。全 key 绝不在此，只有掩码。
@@ -275,20 +278,29 @@ function profileName(id) {
 function syncProfileBusyState() {
   if (!els.profileList) return;
   els.profileList.querySelectorAll(".prow").forEach((row) => {
-    const isTarget = !!(busyOp && busyOp.kind === "activate" && row.getAttribute("data-id") === busyOp.id);
+    const rowId = row.getAttribute("data-id");
+    const isTarget = !!(
+      (busyOp && busyOp.kind === "activate" && rowId === busyOp.id) ||
+      (activationOp && activationOp.kind === "activate" && rowId === activationOp.id)
+    );
     row.classList.toggle("pworking", isTarget);
     row.querySelectorAll("button[data-act]").forEach((btn) => {
-      btn.disabled = busy;
-      if (btn.getAttribute("data-act") === "activate") {
-        btn.textContent = isTarget ? "正在启用…" : "设为当前";
+      const act = btn.getAttribute("data-act");
+      btn.disabled = busy || (activationInFlight && act === "activate");
+      if (act === "activate") {
+        btn.textContent = isTarget ? "已提交" : "设为当前";
       }
     });
   });
 }
 
+function sameOp(a, b) {
+  return !!(a && b && a.kind === b.kind && (a.id || "") === (b.id || ""));
+}
+
 function scheduleBusyMsg(ms, op, text) {
   const timer = setTimeout(() => {
-    if (busy && busyOp && busyOp.kind === op.kind && busyOp.id === op.id) setMsg(text);
+    if (busy && sameOp(busyOp, op)) setMsg(text);
   }, ms);
   busyMsgTimers.push(timer);
 }
@@ -302,15 +314,11 @@ function startFetchModelsFeedback(id) {
 
 function startActivateFeedback(id, skipVerify) {
   const name = profileName(id);
-  clearBusyMsgTimers();
   if (skipVerify) {
-    setMsg("正在启用「" + name + "」：已跳过上游校验，正在启动正式代理并探活…");
-    scheduleBusyMsg(3500, { kind: "activate", id }, "仍在等待正式代理探活完成。完成后会自动应用，失败会保留原配置。");
+    setMsg("已提交「" + name + "」：跳过上游校验，后台启动正式代理并探活。完成后会提示结果。");
     return;
   }
-  setMsg("正在启用「" + name + "」：先用临时代理校验上游，网络慢时可能需要约 20 秒…");
-  scheduleBusyMsg(4500, { kind: "activate", id }, "仍在等待上游校验响应。可以继续查看日志/报告，请不要重复切换配置。");
-  scheduleBusyMsg(18000, { kind: "activate", id }, "上游校验仍未返回，接近本次等待上限。完成后会自动切换，或给出重试/跳过验证提示。");
+  setMsg("已提交「" + name + "」：后台校验上游并准备正式代理。完成后会提示结果。");
 }
 
 function startSaveConnectionFeedback(id, active) {
@@ -362,20 +370,42 @@ function startDoctorFeedback() {
 function setBusy(on, op) {
   busy = on;
   busyOp = on ? (op || { kind: "global" }) : null;
+  const activationBusy = on && busyOp && busyOp.kind === "activate";
   if (!on) clearBusyMsgTimers();
   [
     els.oneClickBtn, els.stopBtn, els.newBtn,
     els.wizSaveBtn, els.wizFetchBtn, els.wizCancelBtn,
     els.connSaveBtn, els.connFetchBtn, els.connClearBtn, els.connCancelBtn,
-    els.metaSaveBtn, els.metaCancelBtn, els.skipActivateBtn, els.doctorBtn,
+    els.metaSaveBtn, els.metaCancelBtn, els.skipActivateBtn,
     // 端口输入也纳入忙碌禁用：忙碌中改端口会与在途操作竞态（修 P1-c 前端侧）。
     els.proxyPort, els.sandboxPort,
   ].forEach((b) => b && (b.disabled = on));
+  if (els.doctorBtn) els.doctorBtn.disabled = on && !activationBusy;
   // 模式切换按钮同样禁用：忙碌中切官方会与「一键开始」竞态（修 P1-b 前端侧）。
   if (els.modeSeg) els.modeSeg.querySelectorAll(".seg-btn").forEach((b) => (b.disabled = on));
   syncProfileBusyState();
   // 松开忙碌时，把模型必填保存门控交回门（避免 setBusy(false) 覆盖门控）。
   if (!on) { refreshWizGate(); refreshConnGate(); }
+  syncActivationControls();
+}
+
+function syncActivationControls() {
+  const writeLocked = busy;
+  [
+    els.newBtn, els.proxyPort, els.sandboxPort,
+    els.connClearBtn, els.metaSaveBtn,
+  ].forEach((b) => b && (b.disabled = writeLocked));
+  if (els.modeSeg) els.modeSeg.querySelectorAll(".seg-btn").forEach((b) => (b.disabled = writeLocked));
+  if (els.skipActivateBtn) els.skipActivateBtn.disabled = busy;
+  syncProfileBusyState();
+  refreshWizGate();
+  refreshConnGate();
+}
+
+function setActivationInFlight(on, op) {
+  activationInFlight = on;
+  activationOp = on ? op : null;
+  syncActivationControls();
 }
 
 async function call(cmd, args) {
@@ -945,8 +975,12 @@ async function doDelete(id) {
 // 设为当前：走后端切换事务（校验→起正式→健康才提交）。
 // 返回体 committed:true=已生效；committed:false=未生效（可能可 skip）；抛错=回滚/中止。
 async function activate(id, skipVerify) {
+  if (activationInFlight) {
+    setMsg("已有配置应用在后台完成。可以查看日志、反馈或自检；请稍后再提交另一条配置。");
+    return;
+  }
   hideSkip();
-  setBusy(true, { kind: "activate", id });
+  setActivationInFlight(true, { kind: "activate", id });
   startActivateFeedback(id, !!skipVerify);
   try {
     const r = await call("set_active_profile", { id, skipVerify: !!skipVerify });
@@ -962,7 +996,7 @@ async function activate(id, skipVerify) {
     await loadConfig();
     setMsg("设为当前失败：" + e, "err");
   } finally {
-    setBusy(false);
+    setActivationInFlight(false);
     await refreshStatus();
   }
 }
@@ -1010,16 +1044,25 @@ async function openBrowser() {
 }
 
 async function runDoctor() {
-  if (busy) return;
-  setBusy(true, { kind: "doctor" });
-  startDoctorFeedback();
+  const activationBusy = activationInFlight || (busy && busyOp && busyOp.kind === "activate");
+  if (doctorInFlight || (busy && !activationBusy)) return;
+  doctorInFlight = true;
+  if (els.doctorBtn) els.doctorBtn.disabled = true;
+  if (activationBusy) {
+    setMsg("自检中：配置后台应用仍在继续。自检只读取当前配置摘要和本地依赖状态。");
+  } else {
+    setBusy(true, { kind: "doctor" });
+    startDoctorFeedback();
+  }
   try {
     const out = await call("run_doctor");
     setMsg(out, out.includes("失败 0") ? "ok" : null);
   } catch (e) {
     setMsg("自检失败：" + e, "err");
   } finally {
-    setBusy(false);
+    doctorInFlight = false;
+    if (els.doctorBtn) els.doctorBtn.disabled = busy && busyOp && busyOp.kind !== "activate";
+    if (!activationBusy) setBusy(false);
   }
 }
 

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -106,6 +106,8 @@ function mockInvoke(cmd, args) {
       return Promise.resolve({ url: "http://127.0.0.1:8990", msg: "（预览模式：假装已就绪）", action: "started" });
     case "status":
       return Promise.resolve({ proxy: "amber", sandbox: "amber", upstream: "amber" });
+    case "boot_error":
+      return Promise.resolve(null);
     case "app_version":
       return Promise.resolve("0.0.0-preview");
     case "run_doctor":
@@ -1148,6 +1150,16 @@ function wire() {
 window.addEventListener("DOMContentLoaded", async () => {
   wire();
   await loadConfig();
+  if (!PREVIEW && window.__TAURI__.event) {
+    window.__TAURI__.event.listen("boot://failed", (e) => {
+      setMsg("自动启动未成功：" + (e.payload || "未知原因") + "\n可检查配置后点「一键开始」重试。", "err");
+      refreshStatus();
+    });
+  }
+  try {
+    const bootError = await call("boot_error");
+    if (bootError) setMsg("自动启动未成功：" + bootError + "\n可检查配置后点「一键开始」重试。", "err");
+  } catch (e) {}
   try { els.verLabel.textContent = "v" + (await call("app_version")); } catch (e) {}
   await refreshStatus();
   if (PREVIEW) {


### PR DESCRIPTION
## Summary

本地实现 native-entry + 后台常驻 Slice A/B/C，并根据实机反馈收紧默认启动策略：

- 普通点击 CSSwitch 默认显示/聚焦配置面板，不再直接打开 Science
- 自动启动 Science 仅保留为 opt-in：`CSSWITCH_AUTO_BOOT_ON_LAUNCH=1`
- 新增偏好菜单、关窗隐藏、显式退出清理入口、单实例二次启动回面板
- boot 失败会回到配置面板，并通过 boot_error / boot://failed 显示错误
- active profile 清 key / 删除 profile 时补充运行态撤销测试
- Slice C WebView 只是 opt-in spike：`CSSWITCH_SCIENCE_WEBVIEW_SPIKE=1`，默认浏览器兜底

## Local gates

local gate green:

- `node --check desktop/src/main.js`
- `git diff --check`
- `cargo test --manifest-path desktop/src-tauri/Cargo.toml`
- `bash test/run-rust.sh`
- `bash test/run_all.sh`
- `cargo build --manifest-path desktop/src-tauri/Cargo.toml`
- 临时 HOME 下 debug 二进制启动 8 秒存活

Follow-up blocker fix gate:

- `cargo test --manifest-path desktop/src-tauri/Cargo.toml decide_launch -- --nocapture`
- `cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --check`
- `node --check desktop/src/main.js`
- `git diff --check`
- `npm run tauri -- build`
- 本机 `/Applications/CSSwitch.app` 已用 #46 最新构建替换，ad-hoc codesign verify 通过

## Not claimed

未验证 CI green、GUI E2E、live provider、real account、true HOME live、DMG parity、Developer ID signing、notarization、Gatekeeper。

合并/发布前仍需用户在场真机手测：偏好菜单、关窗隐藏、单实例二次启动、退出清理、boot 失败回面板；并确认普通点击 CSSwitch 先回配置面板，不直接打开 Science。
