### PR TITLE
test(contract): freeze S1 profile and model discovery DTOs

### DIFF
--- a/desktop/src-tauri/src/runtime/model_discovery.rs
+++ b/desktop/src-tauri/src/runtime/model_discovery.rs
@@ -75,6 +75,72 @@ fn discovery_adapter(
     }
 }
 
+fn build_fetch_models_contract_response(
+    outcome: &scratch::ProbeOutcome,
+    status: Option<u16>,
+    body: &str,
+    builtin: &[&str],
+) -> Result<Value, String> {
+    match outcome {
+        scratch::ProbeOutcome::Ok => {
+            let v: Value =
+                serde_json::from_str(body).map_err(|e| format!("解析模型列表失败：{e}"))?;
+            let live: Vec<(String, Option<bool>)> = v
+                .get("data")
+                .and_then(|d| d.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|m| {
+                            let id = m.get("id")?.as_str()?.to_string();
+                            let st = m.get("supports_tools").and_then(|b| b.as_bool());
+                            Some((id, st))
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            if live.is_empty() {
+                return Ok(json!({
+                    "models": merge_and_sort_models(vec![], builtin),
+                    "source": "builtin", "error_kind": null, "upstream_status": 200
+                }));
+            }
+            Ok(json!({
+                "models": merge_and_sort_models(live, builtin),
+                "source": "live", "error_kind": null, "upstream_status": 200
+            }))
+        }
+        scratch::ProbeOutcome::Auth(code) => {
+            Err(format!("上游拒绝（{code}），key 或权限可能有误。"))
+        }
+        other => {
+            let source = scratch::discovery_fallback_source(other);
+            let error_kind = if source == "network" {
+                json!("network")
+            } else {
+                json!(null)
+            };
+            Ok(json!({
+                "models": merge_and_sort_models(vec![], builtin),
+                "source": source,
+                "error_kind": error_kind,
+                "upstream_status": status
+            }))
+        }
+    }
+}
+
+fn live_model_count_from_body(body: &str) -> Result<usize, String> {
+    let v: Value = serde_json::from_str(body).map_err(|e| format!("解析模型列表失败：{e}"))?;
+    Ok(v.get("data")
+        .and_then(|d| d.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter(|m| m.get("id").and_then(|id| id.as_str()).is_some())
+                .count()
+        })
+        .unwrap_or(0))
+}
+
 /// 「获取可用模型」——纯 scratch 探测：只用临时代理探候选 base_url/key 的 /v1/models，
 /// 绝不写 config、不改 AppState、不碰正在服务 Science 的正式代理。
 pub(crate) fn fetch_models(
@@ -128,57 +194,30 @@ pub(crate) fn fetch_models(
         Some(&trace),
     );
     let builtin = tpl.builtin_models;
-    match scratch::classify(res.status) {
+    let outcome = scratch::classify(res.status);
+    match &outcome {
         scratch::ProbeOutcome::Ok => {
             trace.stage(OperationStage::ScratchUpstreamProbe, "outcome=ok");
-            let v: Value =
-                serde_json::from_str(&res.body).map_err(|e| format!("解析模型列表失败：{e}"))?;
-            let live: Vec<(String, Option<bool>)> = v
-                .get("data")
-                .and_then(|d| d.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|m| {
-                            let id = m.get("id")?.as_str()?.to_string();
-                            let st = m.get("supports_tools").and_then(|b| b.as_bool());
-                            Some((id, st))
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
-            if live.is_empty() {
+            let live_count = live_model_count_from_body(&res.body)?;
+            let response =
+                build_fetch_models_contract_response(&outcome, res.status, &res.body, builtin)?;
+            if live_count == 0 {
                 trace.finish("ok source=builtin empty_live");
-                return Ok(json!({
-                    "models": merge_and_sort_models(vec![], builtin),
-                    "source": "builtin", "error_kind": null, "upstream_status": 200
-                }));
+            } else {
+                trace.finish(format!("ok source=live count={live_count}"));
             }
-            trace.finish(format!("ok source=live count={}", live.len()));
-            Ok(json!({
-                "models": merge_and_sort_models(live, builtin),
-                "source": "live", "error_kind": null, "upstream_status": 200
-            }))
+            Ok(response)
         }
         scratch::ProbeOutcome::Auth(code) => {
             trace.finish(format!("rejected status={code}"));
-            Err(format!("上游拒绝（{code}），key 或权限可能有误。"))
+            build_fetch_models_contract_response(&outcome, res.status, &res.body, builtin)
         }
         // 非 200 且非 Auth：一律 builtin 兜底，但按语义分「发现不支持」(4xx) 与「网络/上游临时」(5xx/429/无响应)，
         // 供前端区分提示（spec v3 §3.4.3）。绝不把 Auth 混进来掩盖坏 key。
         other => {
-            let source = scratch::discovery_fallback_source(&other);
+            let source = scratch::discovery_fallback_source(other);
             trace.finish(format!("fallback source={source} outcome={other:?}"));
-            let error_kind = if source == "network" {
-                json!("network")
-            } else {
-                json!(null)
-            };
-            Ok(json!({
-                "models": merge_and_sort_models(vec![], builtin),
-                "source": source,
-                "error_kind": error_kind,
-                "upstream_status": res.status
-            }))
+            build_fetch_models_contract_response(&outcome, res.status, &res.body, builtin)
         }
     }
 }
@@ -186,10 +225,10 @@ pub(crate) fn fetch_models(
 #[cfg(test)]
 mod tests {
     use super::{
-        discovery_adapter, effective_api_format_from_dir, resolve_probe_key,
-        resolve_probe_key_from_dir,
+        build_fetch_models_contract_response, discovery_adapter, effective_api_format_from_dir,
+        resolve_probe_key, resolve_probe_key_from_dir,
     };
-    use crate::{config, runtime::profile::create_profile_inner};
+    use crate::{config, runtime::profile::create_profile_inner, scratch::ProbeOutcome};
 
     fn tmpdir_model_discovery() -> std::path::PathBuf {
         let base = std::env::temp_dir().join(format!(
@@ -265,5 +304,67 @@ mod tests {
             effective_api_format_from_dir(&d, tpl, None, None).unwrap(),
             "anthropic"
         );
+    }
+
+    #[test]
+    fn fetch_models_contract_maps_live_and_empty_live_to_frozen_shape() {
+        let live = build_fetch_models_contract_response(
+            &ProbeOutcome::Ok,
+            Some(200),
+            r#"{"data":[{"id":"m-live","supports_tools":true}]}"#,
+            &["m-builtin"],
+        )
+        .unwrap();
+        assert_eq!(live["source"], "live");
+        assert_eq!(live["error_kind"], serde_json::Value::Null);
+        assert_eq!(live["upstream_status"], 200);
+        assert_eq!(live["models"][0]["id"], "m-live");
+        assert_eq!(live["models"][0]["supports_tools"], true);
+
+        let empty_live = build_fetch_models_contract_response(
+            &ProbeOutcome::Ok,
+            Some(200),
+            r#"{"data":[]}"#,
+            &["m-builtin"],
+        )
+        .unwrap();
+        assert_eq!(empty_live["source"], "builtin");
+        assert_eq!(empty_live["error_kind"], serde_json::Value::Null);
+        assert_eq!(empty_live["upstream_status"], 200);
+        assert_eq!(empty_live["models"][0]["id"], "m-builtin");
+    }
+
+    #[test]
+    fn fetch_models_contract_keeps_auth_hard_and_soft_fallbacks_typed() {
+        let auth = build_fetch_models_contract_response(
+            &ProbeOutcome::Auth(401),
+            Some(401),
+            "",
+            &["m-builtin"],
+        );
+        assert!(auth.unwrap_err().contains("401"));
+
+        let unsupported = build_fetch_models_contract_response(
+            &ProbeOutcome::Unsupported(405),
+            Some(405),
+            "",
+            &["m-builtin"],
+        )
+        .unwrap();
+        assert_eq!(unsupported["source"], "unsupported");
+        assert_eq!(unsupported["error_kind"], serde_json::Value::Null);
+        assert_eq!(unsupported["upstream_status"], 405);
+        assert_eq!(unsupported["models"][0]["id"], "m-builtin");
+
+        let network = build_fetch_models_contract_response(
+            &ProbeOutcome::NoResponse,
+            None,
+            "",
+            &["m-builtin"],
+        )
+        .unwrap();
+        assert_eq!(network["source"], "network");
+        assert_eq!(network["error_kind"], "network");
+        assert!(network["upstream_status"].is_null());
     }
 }

--- a/desktop/src-tauri/src/runtime/profile.rs
+++ b/desktop/src-tauri/src/runtime/profile.rs
@@ -617,6 +617,42 @@ mod tests {
     }
 
     #[test]
+    fn get_config_redaction_never_projects_full_key_material() {
+        let d = tmpdir_profile();
+        let full_key = "sk-contract-prefix-secret-middle-tail9999";
+        let id =
+            create_profile_inner(&d, "glm", "GLM", Some(full_key), None, Some("glm-5.2")).unwrap();
+        let v = build_get_config(&d).unwrap();
+        let p = v["profiles"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|p| p["id"] == id)
+            .unwrap();
+
+        assert!(
+            p.get("api_key").is_none() || p["api_key"].is_null(),
+            "frontend-safe projection must not expose api_key"
+        );
+        assert_eq!(p["has_key"], true);
+        assert_eq!(
+            p["key"], p["key_masked"],
+            "legacy key remains masked alias only"
+        );
+        assert!(p["key_masked"].as_str().unwrap().ends_with("9999"));
+
+        let projected = serde_json::to_string(p).unwrap();
+        assert!(
+            !projected.contains(full_key),
+            "frontend-safe projection leaked the full key"
+        );
+        assert!(
+            !projected.contains("contract-prefix-secret-middle"),
+            "frontend-safe projection leaked key body material"
+        );
+    }
+
+    #[test]
     fn get_config_returns_notes_so_rename_does_not_wipe_them() {
         // M1 回归：build_get_config 必须回传 notes，否则前端读到空、下次改名把备注静默清掉。
         let d = tmpdir_profile();
@@ -650,6 +686,102 @@ mod tests {
             "openai_models_or_manual"
         );
         assert_eq!(custom["capabilities"]["base_url_required"], true);
+    }
+
+    #[test]
+    fn all_templates_include_the_full_capability_contract_shape() {
+        let templates = build_list_templates();
+        let template_fields = [
+            "id",
+            "name",
+            "category",
+            "api_format",
+            "adapter",
+            "base_url",
+            "base_url_editable",
+            "requires_model_override",
+            "builtin_models",
+            "icon",
+            "icon_color",
+            "website_url",
+            "capabilities",
+        ];
+        let capability_fields = [
+            "base_url_required",
+            "model_required",
+            "model_discovery",
+            "supports_thinking_policy",
+            "thinking_policy",
+            "supports_tools_hint",
+        ];
+        for template in templates {
+            let id = template["id"].as_str().unwrap_or("<missing-id>");
+            for field in template_fields {
+                assert!(
+                    template.get(field).is_some(),
+                    "template {id} missing field {field}"
+                );
+            }
+            assert!(
+                template["builtin_models"].is_array(),
+                "template {id} builtin_models"
+            );
+            assert!(
+                template["base_url_editable"].is_boolean(),
+                "template {id} base_url_editable"
+            );
+            assert!(
+                template["requires_model_override"].is_boolean(),
+                "template {id} requires_model_override"
+            );
+            let capabilities = &template["capabilities"];
+            for field in capability_fields {
+                assert!(
+                    capabilities.get(field).is_some(),
+                    "template {id} missing capability {field}"
+                );
+            }
+            assert!(
+                capabilities["base_url_required"].is_boolean(),
+                "template {id} base_url_required"
+            );
+            assert!(
+                capabilities["model_required"].is_boolean(),
+                "template {id} model_required"
+            );
+            assert!(
+                capabilities["supports_thinking_policy"].is_boolean(),
+                "template {id} supports_thinking_policy"
+            );
+            assert!(
+                matches!(
+                    capabilities["thinking_policy"].as_str(),
+                    Some("" | "adaptive" | "enabled")
+                ),
+                "template {id} thinking_policy"
+            );
+            assert_eq!(
+                capabilities["supports_thinking_policy"].as_bool().unwrap(),
+                !capabilities["thinking_policy"].as_str().unwrap().is_empty(),
+                "template {id} supports_thinking_policy must match thinking_policy"
+            );
+            assert!(
+                matches!(
+                    capabilities["model_discovery"].as_str(),
+                    Some(
+                        "builtin_static" | "anthropic_models_or_manual" | "openai_models_or_manual"
+                    )
+                ),
+                "template {id} model_discovery"
+            );
+            assert!(
+                matches!(
+                    capabilities["supports_tools_hint"].as_str(),
+                    Some("native" | "passthrough" | "translated" | "unknown")
+                ),
+                "template {id} supports_tools_hint"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

S1 contract hardening slice. #46 has been merged, and this PR has been rebased onto `main`; the diff now contains only the S1 contract tests/helpers.

- freeze `fetch_models` contract shape for live, builtin-empty, auth hard error, unsupported, and network/no-response outcomes
- assert `get_config` redaction does not expose full key material; legacy `key` remains a masked alias only
- assert `list_templates` exposes the full template/capability DTO shape, including `thinking_policy` enum and `supports_thinking_policy` consistency
- preserve existing `fetch_models` success trace semantics for live count and empty-live fallback

## Scope boundaries

This is S1 contract hardening only. It is not a UI redesign.

Not included:

- S1b Rust gateway
- upstream proxy or MCP transport work
- python-ectomy
- watchdog or auto-recovery
- #2/#3 large refactors

## Validation

Local gates run after rebasing onto `main` on 2026-07-09:

- `git diff --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --manifest-path desktop/src-tauri/Cargo.toml --check`
- `bash test/run-contract.sh`
- `bash test/run_all.sh` (5 layers pass; current-env clean:YES; release-ready green:YES)

Prior focused checks for this slice:

- `PATH="$HOME/.cargo/bin:$PATH" cargo test --manifest-path desktop/src-tauri/Cargo.toml fetch_models_contract -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --manifest-path desktop/src-tauri/Cargo.toml all_templates_include_the_full_capability_contract_shape -- --nocapture`

Read-only subagent reviews before rebase:

- contract/DTO: Approved after fixing `thinking_policy` coverage and trace semantics
- secret/redaction: Approved
- scope boundary: Approved

## Not verified / not claimed

- CI green
- installed app GUI E2E or packaged GUI runtime E2E
- live provider or real key
- real `~/.claude-science`
- DMG signing, notarization, or Gatekeeper