### PR TITLE
Harden DeepSeek Rust gateway parity

### DIFF
--- a/desktop/gateway/src/messages.rs
+++ b/desktop/gateway/src/messages.rs
@@ -18,6 +18,12 @@ pub struct UpstreamError {
     pub detail: String,
 }
 
+#[derive(Debug)]
+pub struct UpstreamStream {
+    pub response: Response,
+    pub first: Vec<u8>,
+}
+
 fn client() -> Result<Client, UpstreamError> {
     Client::builder()
         .timeout(Duration::from_secs(120))
@@ -43,6 +49,10 @@ fn post(cfg: &GatewayConfig, body: Vec<u8>) -> Result<Response, UpstreamError> {
         })
 }
 
+fn retry_delay(attempt: usize) {
+    std::thread::sleep(Duration::from_millis(800 * attempt as u64));
+}
+
 fn map_http_error(resp: Response) -> UpstreamError {
     let status = resp.status().as_u16();
     let body = resp.text().unwrap_or_default();
@@ -63,33 +73,120 @@ fn map_http_error(resp: Response) -> UpstreamError {
 }
 
 pub fn post_nonstream(cfg: &GatewayConfig, body: Vec<u8>) -> Result<UpstreamBody, UpstreamError> {
-    let mut resp = post(cfg, body)?;
-    if !resp.status().is_success() {
-        return Err(map_http_error(resp));
+    let mut last_error = None;
+    for attempt in 1..=4 {
+        let mut resp = match post(cfg, body.clone()) {
+            Ok(resp) => resp,
+            Err(e) => {
+                last_error = Some(e);
+                if attempt < 4 {
+                    retry_delay(attempt);
+                    continue;
+                }
+                break;
+            }
+        };
+        if !resp.status().is_success() {
+            return Err(map_http_error(resp));
+        }
+        let status = resp.status().as_u16();
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("application/json")
+            .to_string();
+        let mut body = Vec::new();
+        match resp.read_to_end(&mut body) {
+            Ok(_) => {
+                return Ok(UpstreamBody {
+                    status,
+                    content_type,
+                    body,
+                });
+            }
+            Err(e) => {
+                last_error = Some(UpstreamError {
+                    status: 502,
+                    detail: e.to_string(),
+                });
+                if attempt < 4 {
+                    retry_delay(attempt);
+                    continue;
+                }
+            }
+        }
     }
-    let status = resp.status().as_u16();
-    let content_type = resp
-        .headers()
-        .get(reqwest::header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("application/json")
-        .to_string();
-    let mut body = Vec::new();
-    resp.read_to_end(&mut body).map_err(|e| UpstreamError {
+    Err(last_error.unwrap_or_else(|| UpstreamError {
         status: 502,
-        detail: e.to_string(),
-    })?;
-    Ok(UpstreamBody {
-        status,
-        content_type,
-        body,
-    })
+        detail: "upstream request failed".to_string(),
+    }))
 }
 
-pub fn open_stream(cfg: &GatewayConfig, body: Vec<u8>) -> Result<Response, UpstreamError> {
-    let resp = post(cfg, body)?;
-    if !resp.status().is_success() {
-        return Err(map_http_error(resp));
+fn read_first_line(resp: &mut Response) -> Result<Vec<u8>, UpstreamError> {
+    let mut first = Vec::new();
+    let mut byte = [0_u8; 1];
+    while first.len() < 65_536 {
+        match resp.read(&mut byte) {
+            Ok(0) => break,
+            Ok(_) => {
+                first.push(byte[0]);
+                if byte[0] == b'\n' {
+                    break;
+                }
+            }
+            Err(e) => {
+                return Err(UpstreamError {
+                    status: 502,
+                    detail: e.to_string(),
+                });
+            }
+        }
     }
-    Ok(resp)
+    if first.is_empty() {
+        return Err(UpstreamError {
+            status: 502,
+            detail: "upstream 200 but empty body".to_string(),
+        });
+    }
+    Ok(first)
+}
+
+pub fn open_stream(cfg: &GatewayConfig, body: Vec<u8>) -> Result<UpstreamStream, UpstreamError> {
+    let mut last_error = None;
+    for attempt in 1..=4 {
+        let mut resp = match post(cfg, body.clone()) {
+            Ok(resp) => resp,
+            Err(e) => {
+                last_error = Some(e);
+                if attempt < 4 {
+                    retry_delay(attempt);
+                    continue;
+                }
+                break;
+            }
+        };
+        if !resp.status().is_success() {
+            return Err(map_http_error(resp));
+        }
+        match read_first_line(&mut resp) {
+            Ok(first) => {
+                return Ok(UpstreamStream {
+                    response: resp,
+                    first,
+                });
+            }
+            Err(e) => {
+                last_error = Some(e);
+                if attempt < 4 {
+                    retry_delay(attempt);
+                    continue;
+                }
+            }
+        }
+    }
+    Err(last_error.unwrap_or_else(|| UpstreamError {
+        status: 502,
+        detail: "upstream stream failed".to_string(),
+    }))
 }

--- a/desktop/gateway/src/server.rs
+++ b/desktop/gateway/src/server.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
+use std::sync::mpsc;
 use std::thread;
+use std::time::Duration;
 
 use serde_json::{json, Value};
 
@@ -51,11 +53,16 @@ fn read_head(stream: &mut TcpStream) -> Result<RequestHead, String> {
 }
 
 fn content_length(headers: &HashMap<String, String>) -> Result<usize, String> {
-    headers
-        .get("content-length")
-        .ok_or("missing content-length".to_string())?
-        .parse::<usize>()
-        .map_err(|_| "invalid content-length".to_string())
+    let Some(raw) = headers.get("content-length") else {
+        return Ok(0);
+    };
+    let parsed = raw
+        .parse::<i64>()
+        .map_err(|_| "invalid Content-Length".to_string())?;
+    if parsed < 0 {
+        return Err("invalid Content-Length".to_string());
+    }
+    Ok(parsed as usize)
 }
 
 fn read_body(stream: &mut TcpStream, len: usize) -> Result<Vec<u8>, String> {
@@ -89,28 +96,41 @@ fn write_json(stream: &mut TcpStream, status: u16, reason: &str, value: Value) {
     write_response(stream, status, reason, "application/json", &body);
 }
 
-fn error_json(stream: &mut TcpStream, status: u16, reason: &str, detail: &str) {
+fn typed_error_json(
+    stream: &mut TcpStream,
+    status: u16,
+    reason: &str,
+    error_type: &str,
+    message: &str,
+) {
     write_json(
         stream,
         status,
         reason,
-        json!({"error": {"type": "csswitch_gateway_error", "message": detail}}),
+        json!({
+            "type": "error",
+            "error": {
+                "type": error_type,
+                "message": message,
+            },
+        }),
     );
 }
 
 fn forbidden_json(stream: &mut TcpStream) {
-    write_json(
-        stream,
-        403,
-        "Forbidden",
-        json!({
-            "type": "error",
-            "error": {
-                "type": "permission_error",
-                "message": "forbidden",
-            },
-        }),
-    );
+    typed_error_json(stream, 403, "Forbidden", "permission_error", "forbidden");
+}
+
+fn invalid_request_json(stream: &mut TcpStream, detail: &str) {
+    typed_error_json(stream, 400, "Bad Request", "invalid_request_error", detail);
+}
+
+fn not_found_json(stream: &mut TcpStream, path: &str) {
+    typed_error_json(stream, 404, "Not Found", "not_found_error", path);
+}
+
+fn api_error_json(stream: &mut TcpStream, status: u16, detail: &str) {
+    typed_error_json(stream, status, status_reason(status), "api_error", detail);
 }
 
 fn status_reason(status: u16) -> &'static str {
@@ -146,7 +166,7 @@ fn handle_get(stream: &mut TcpStream, cfg: &GatewayConfig, target: &str) {
             json!({"status": "ok", "provider": cfg.provider}),
         ),
         "/v1/models" => write_json(stream, 200, "OK", models::deepseek_models_response()),
-        _ => error_json(stream, 404, "Not Found", "not found"),
+        _ => not_found_json(stream, &path),
     }
 }
 
@@ -160,7 +180,13 @@ fn write_chunk(stream: &mut TcpStream, chunk: &[u8]) -> std::io::Result<()> {
 fn stream_error_event(detail: &str) -> Vec<u8> {
     format!(
         "event: error\ndata: {}\n\n",
-        json!({"error": {"message": detail}})
+        json!({
+            "type": "error",
+            "error": {
+                "type": "api_error",
+                "message": detail,
+            },
+        })
     )
     .into_bytes()
 }
@@ -170,11 +196,35 @@ fn handle_stream(stream: &mut TcpStream, cfg: &GatewayConfig, body: Vec<u8>) {
         stream,
         "HTTP/1.1 200 OK\r\ncontent-type: text/event-stream\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n"
     );
-    match messages::open_stream(cfg, body) {
+    let (tx, rx) = mpsc::channel();
+    let cfg_for_open = cfg.clone();
+    thread::spawn(move || {
+        let _ = tx.send(messages::open_stream(&cfg_for_open, body));
+    });
+    let upstream = loop {
+        match rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(result) => break result,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if write_chunk(stream, b": csswitch-keepalive\n\n").is_err() {
+                    return;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                break Err(messages::UpstreamError {
+                    status: 502,
+                    detail: "upstream stream failed".to_string(),
+                });
+            }
+        }
+    };
+    match upstream {
         Ok(mut upstream) => {
+            if write_chunk(stream, &upstream.first).is_err() {
+                return;
+            }
             let mut buf = [0_u8; 8192];
             loop {
-                match upstream.read(&mut buf) {
+                match upstream.response.read(&mut buf) {
                     Ok(0) => break,
                     Ok(n) => {
                         if write_chunk(stream, &buf[..n]).is_err() {
@@ -200,7 +250,7 @@ fn handle_messages(stream: &mut TcpStream, cfg: &GatewayConfig, body: Vec<u8>) {
     let raw: Value = match serde_json::from_slice(&body) {
         Ok(v) => v,
         Err(e) => {
-            error_json(stream, 400, "Bad Request", &e.to_string());
+            invalid_request_json(stream, &e.to_string());
             return;
         }
     };
@@ -208,7 +258,7 @@ fn handle_messages(stream: &mut TcpStream, cfg: &GatewayConfig, body: Vec<u8>) {
     let transformed = match policy::transform_request(raw) {
         Ok(body) => body,
         Err(e) => {
-            error_json(stream, 400, "Bad Request", &e);
+            invalid_request_json(stream, &e);
             return;
         }
     };
@@ -224,7 +274,7 @@ fn handle_messages(stream: &mut TcpStream, cfg: &GatewayConfig, body: Vec<u8>) {
             &resp.content_type,
             &resp.body,
         ),
-        Err(e) => error_json(stream, e.status, status_reason(e.status), &e.detail),
+        Err(e) => api_error_json(stream, e.status, &e.detail),
     }
 }
 
@@ -236,24 +286,28 @@ fn handle_post(stream: &mut TcpStream, cfg: &GatewayConfig, target: &str, head: 
             return;
         }
     };
-    if path != "/v1/messages" {
-        error_json(stream, 404, "Not Found", "not found");
-        return;
-    }
     let len = match content_length(&head.headers) {
         Ok(len) => len,
         Err(e) => {
-            error_json(stream, 400, "Bad Request", &e);
+            invalid_request_json(stream, &e);
             return;
         }
     };
-    let body = match read_body(stream, len) {
-        Ok(body) => body,
-        Err(e) => {
-            error_json(stream, 400, "Bad Request", &e);
-            return;
+    let body = if len == 0 {
+        b"{}".to_vec()
+    } else {
+        match read_body(stream, len) {
+            Ok(body) => body,
+            Err(e) => {
+                invalid_request_json(stream, &e);
+                return;
+            }
         }
     };
+    if path != "/v1/messages" {
+        not_found_json(stream, &path);
+        return;
+    }
     handle_messages(stream, cfg, body);
 }
 
@@ -261,7 +315,7 @@ fn handle_one(cfg: GatewayConfig, mut stream: TcpStream) {
     let head = match read_head(&mut stream) {
         Ok(head) => head,
         Err(e) => {
-            error_json(&mut stream, 400, "Bad Request", &e);
+            invalid_request_json(&mut stream, &e);
             return;
         }
     };
@@ -272,7 +326,7 @@ fn handle_one(cfg: GatewayConfig, mut stream: TcpStream) {
             let target = head.target.clone();
             handle_post(&mut stream, &cfg, &target, &head)
         }
-        _ => error_json(&mut stream, 404, "Not Found", "not found"),
+        _ => not_found_json(&mut stream, &head.target),
     }
 }
 

--- a/test/test_gateway_rust.py
+++ b/test/test_gateway_rust.py
@@ -46,13 +46,54 @@ def recv_http_head(sock):
     return data
 
 
+def recv_http_all(sock):
+    chunks = []
+    while True:
+        try:
+            chunk = sock.recv(65536)
+        except ConnectionResetError:
+            break
+        if not chunk:
+            break
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def parse_raw_response(raw):
+    head, _, body = raw.partition(b"\r\n\r\n")
+    lines = head.split(b"\r\n")
+    status = int(lines[0].split()[1])
+    headers = {}
+    for line in lines[1:]:
+        key, _, value = line.partition(b":")
+        if key:
+            headers[key.strip().lower().decode()] = value.strip().decode()
+    return status, headers, body
+
+
+def assert_error_shape(testcase, body, error_type):
+    parsed = json.loads(body)
+    testcase.assertEqual(parsed["type"], "error")
+    testcase.assertEqual(parsed["error"]["type"], error_type)
+    testcase.assertIsInstance(parsed["error"]["message"], str)
+    return parsed
+
+
 class MockUpstream(ThreadingHTTPServer):
     allow_reuse_address = True
 
-    def __init__(self, response_body, content_type="application/json"):
+    def __init__(
+        self,
+        response_body,
+        content_type="application/json",
+        status=200,
+        response_delay=0,
+    ):
         self.requests = []
         self.response_body = response_body
         self.content_type = content_type
+        self.status = status
+        self.response_delay = response_delay
         super().__init__(("127.0.0.1", free_port()), MockHandler)
 
 
@@ -70,7 +111,9 @@ class MockHandler(BaseHTTPRequestHandler):
             }
         )
         payload = self.server.response_body
-        self.send_response(200)
+        if self.server.response_delay:
+            time.sleep(self.server.response_delay)
+        self.send_response(self.server.status)
         self.send_header("content-type", self.server.content_type)
         self.send_header("content-length", str(len(payload)))
         self.end_headers()
@@ -98,6 +141,73 @@ class EchoServer:
             with conn:
                 data = conn.recv(4096)
                 conn.sendall(data)
+
+
+class RawUpstream:
+    def __init__(self, handler):
+        self.port = free_port()
+        self.handler = handler
+        self.ready = threading.Event()
+        self.closed = False
+        self.thread = threading.Thread(target=self._serve, daemon=True)
+        self.thread.start()
+        self.ready.wait(2)
+
+    def _serve(self):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as srv:
+            srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            srv.bind(("127.0.0.1", self.port))
+            srv.listen(5)
+            self.ready.set()
+            while not self.closed:
+                try:
+                    conn, _ = srv.accept()
+                except OSError:
+                    return
+                threading.Thread(target=self.handler, args=(conn,), daemon=True).start()
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self.port}/anthropic/v1/messages"
+
+    def close(self):
+        self.closed = True
+        try:
+            with socket.create_connection(("127.0.0.1", self.port), timeout=0.2):
+                pass
+        except OSError:
+            pass
+
+
+def delayed_stream_handler(conn):
+    with conn:
+        conn.recv(65536)
+        time.sleep(1.2)
+        head = (
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: text/event-stream\r\n"
+            "Transfer-Encoding: chunked\r\n\r\n"
+        )
+        first = b"event: message_start\n"
+        conn.sendall(head.encode() + b"15\r\n" + first + b"\r\n0\r\n\r\n")
+
+
+def dropping_stream_handler(conn):
+    with conn:
+        conn.recv(65536)
+        payload = b"event: content_block_delta\ndata: {\"type\":\"content_block_delta\"}\n\n"
+        head = (
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: text/event-stream\r\n"
+            "Transfer-Encoding: chunked\r\n\r\n"
+        )
+        try:
+            conn.sendall(
+                head.encode() + hex(len(payload))[2:].encode() + b"\r\n" + payload + b"\r\n"
+            )
+            conn.sendall(b"1f4\r\n0123456789")
+        except BrokenPipeError:
+            pass
 
 
 class RustGatewayLoopback(unittest.TestCase):
@@ -164,6 +274,34 @@ class RustGatewayLoopback(unittest.TestCase):
         for handle in (proc.stdout, proc.stderr):
             if handle:
                 handle.close()
+
+    def raw_request(self, port, request):
+        with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+            sock.sendall(request)
+            return recv_http_all(sock)
+
+    def raw_post_until(self, port, body, needle, timeout=1.1):
+        with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+            sock.settimeout(timeout)
+            request = (
+                "POST /secret/v1/messages HTTP/1.1\r\n"
+                "Host: 127.0.0.1\r\n"
+                "Content-Type: application/json\r\n"
+                f"Content-Length: {len(body)}\r\n"
+                "Connection: close\r\n\r\n"
+            ).encode() + body
+            started = time.monotonic()
+            sock.sendall(request)
+            chunks = []
+            try:
+                while needle not in b"".join(chunks):
+                    chunk = sock.recv(65536)
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+            except socket.timeout:
+                pass
+            return b"".join(chunks), time.monotonic() - started
 
     def test_auth_and_models(self):
         proc, port = self.start_gateway()
@@ -239,6 +377,140 @@ class RustGatewayLoopback(unittest.TestCase):
             upstream.shutdown()
             upstream.server_close()
 
+    def test_nonstream_upstream_errors_match_python_shape(self):
+        cases = [
+            (401, 401),
+            (429, 429),
+            (500, 502),
+        ]
+        upstream_body = (
+            b'{"type":"error","error":{"type":"authentication_error",'
+            b'"message":"mock upstream error"}}'
+        )
+        for upstream_status, expected_status in cases:
+            with self.subTest(upstream_status=upstream_status):
+                upstream = MockUpstream(upstream_body, status=upstream_status)
+                thread = threading.Thread(target=upstream.serve_forever, daemon=True)
+                thread.start()
+                proc, port = self.start_gateway(
+                    upstream_url=(
+                        f"http://127.0.0.1:{upstream.server_port}"
+                        "/anthropic/v1/messages"
+                    )
+                )
+                try:
+                    request_body = (
+                        b'{"model":"claude-opus-4-8",'
+                        b'"messages":[{"role":"user","content":"hi"}]}'
+                    )
+                    raw = self.raw_request(
+                        port,
+                        (
+                            b"POST /secret/v1/messages HTTP/1.1\r\n"
+                            b"Host: 127.0.0.1\r\n"
+                            b"Content-Type: application/json\r\n"
+                            + f"Content-Length: {len(request_body)}\r\n".encode()
+                            + b"Connection: close\r\n\r\n"
+                            + request_body
+                        ),
+                    )
+                    status, headers, body = parse_raw_response(raw)
+                    self.assertEqual(status, expected_status)
+                    self.assertEqual(int(headers["content-length"]), len(body))
+                    parsed = assert_error_shape(self, body, "api_error")
+                    self.assertIn(f"upstream {upstream_status}", parsed["error"]["message"])
+                finally:
+                    self.stop_gateway(proc)
+                    upstream.shutdown()
+                    upstream.server_close()
+
+    def test_malformed_requests_match_python_error_types(self):
+        proc, port = self.start_gateway()
+        try:
+            cases = [
+                (
+                    b"POST /secret/v1/messages HTTP/1.1\r\n"
+                    b"Host: 127.0.0.1\r\n"
+                    b"Content-Length: nope\r\n"
+                    b"Connection: close\r\n\r\n",
+                    400,
+                    "invalid_request_error",
+                    "invalid Content-Length",
+                ),
+                (
+                    b"POST /secret/v1/messages HTTP/1.1\r\n"
+                    b"Host: 127.0.0.1\r\n"
+                    b"Content-Length: -1\r\n"
+                    b"Connection: close\r\n\r\n",
+                    400,
+                    "invalid_request_error",
+                    "invalid Content-Length",
+                ),
+                (
+                    b"POST /secret/v1/messages HTTP/1.1\r\n"
+                    b"Host: 127.0.0.1\r\n"
+                    b"Connection: close\r\n\r\n",
+                    400,
+                    "invalid_request_error",
+                    "request body must be a JSON object",
+                ),
+                (
+                    b"POST /secret/v1/messages HTTP/1.1\r\n"
+                    b"Host: 127.0.0.1\r\n"
+                    b"Content-Length: 0\r\n"
+                    b"Connection: close\r\n\r\n",
+                    400,
+                    "invalid_request_error",
+                    "request body must be a JSON object",
+                ),
+                (
+                    b"POST /secret/v1/messages HTTP/1.1\r\n"
+                    b"Host: 127.0.0.1\r\n"
+                    b"Content-Length: 2\r\n"
+                    b"Connection: close\r\n\r\n[]",
+                    400,
+                    "invalid_request_error",
+                    "request body must be a JSON object",
+                ),
+                (
+                    b"POST /secret/v1/messages HTTP/1.1\r\n"
+                    b"Host: 127.0.0.1\r\n"
+                    b"Content-Length: 17\r\n"
+                    b"Connection: close\r\n\r\n{\"messages\":null}",
+                    400,
+                    "invalid_request_error",
+                    "request body must be a JSON object",
+                ),
+                (
+                    b"POST /secret/v1/unknown HTTP/1.1\r\n"
+                    b"Host: 127.0.0.1\r\n"
+                    b"Content-Length: 2\r\n"
+                    b"Connection: close\r\n\r\n{}",
+                    404,
+                    "not_found_error",
+                    "/v1/unknown",
+                ),
+                (
+                    b"GET /secret/nope HTTP/1.1\r\n"
+                    b"Host: 127.0.0.1\r\n"
+                    b"Connection: close\r\n\r\n",
+                    404,
+                    "not_found_error",
+                    "/nope",
+                ),
+            ]
+            for raw_request, expected_status, error_type, message_part in cases:
+                with self.subTest(error_type=error_type, message_part=message_part):
+                    status, headers, body = parse_raw_response(
+                        self.raw_request(port, raw_request)
+                    )
+                    self.assertEqual(status, expected_status)
+                    self.assertEqual(int(headers["content-length"]), len(body))
+                    parsed = assert_error_shape(self, body, error_type)
+                    self.assertIn(message_part, parsed["error"]["message"])
+        finally:
+            self.stop_gateway(proc)
+
     def test_stream_passthrough_dechunks_same_payload(self):
         payload = b"event: message_start\ndata: {\"type\":\"message_start\"}\n\n"
         upstream = MockUpstream(payload, content_type="text/event-stream")
@@ -270,6 +542,92 @@ class RustGatewayLoopback(unittest.TestCase):
             self.stop_gateway(proc)
             upstream.shutdown()
             upstream.server_close()
+
+    def test_stream_keepalive_opens_before_upstream_first_byte(self):
+        upstream = RawUpstream(delayed_stream_handler)
+        proc, port = self.start_gateway(upstream_url=upstream.url)
+        try:
+            body = (
+                b'{"model":"claude-opus-4-8","max_tokens":10,"stream":true,'
+                b'"messages":[{"role":"user","content":"hi"}]}'
+            )
+            raw, elapsed = self.raw_post_until(port, body, b": csswitch-keepalive")
+            self.assertIn(b"HTTP/1.1 200", raw)
+            self.assertIn(b"content-type: text/event-stream", raw)
+            self.assertIn(b": csswitch-keepalive", raw)
+            self.assertLess(elapsed, 1.1)
+        finally:
+            self.stop_gateway(proc)
+            upstream.close()
+
+    def test_stream_upstream_status_after_headers_is_sse_error(self):
+        upstream = MockUpstream(
+            b'{"error":"bad key"}',
+            content_type="application/json",
+            status=401,
+        )
+        thread = threading.Thread(target=upstream.serve_forever, daemon=True)
+        thread.start()
+        proc, port = self.start_gateway(
+            upstream_url=f"http://127.0.0.1:{upstream.server_port}/anthropic/v1/messages"
+        )
+        try:
+            body = (
+                b'{"model":"claude-opus-4-8","max_tokens":10,"stream":true,'
+                b'"messages":[{"role":"user","content":"hi"}]}'
+            )
+            raw = self.raw_request(
+                port,
+                (
+                    b"POST /secret/v1/messages HTTP/1.1\r\n"
+                    b"Host: 127.0.0.1\r\n"
+                    b"Content-Type: application/json\r\n"
+                    + f"Content-Length: {len(body)}\r\n".encode()
+                    + b"Connection: close\r\n\r\n"
+                    + body
+                ),
+            )
+            head, _, tail = raw.partition(b"\r\n\r\n")
+            self.assertIn(b"HTTP/1.1 200", head)
+            self.assertIn(b"content-type: text/event-stream", head)
+            self.assertIn(b"event: error", tail)
+            self.assertIn(b'"type":"api_error"', tail)
+            self.assertIn(b"upstream 401", tail)
+            self.assertTrue(raw.rstrip().endswith(b"0"))
+            self.assertNotIn(b"HTTP/1.1 401", raw)
+        finally:
+            self.stop_gateway(proc)
+            upstream.shutdown()
+            upstream.server_close()
+
+    def test_stream_midstream_truncation_ends_with_sse_error(self):
+        upstream = RawUpstream(dropping_stream_handler)
+        proc, port = self.start_gateway(upstream_url=upstream.url)
+        try:
+            body = (
+                b'{"model":"claude-opus-4-8","max_tokens":10,"stream":true,'
+                b'"messages":[{"role":"user","content":"hi"}]}'
+            )
+            raw = self.raw_request(
+                port,
+                (
+                    b"POST /secret/v1/messages HTTP/1.1\r\n"
+                    b"Host: 127.0.0.1\r\n"
+                    b"Content-Type: application/json\r\n"
+                    + f"Content-Length: {len(body)}\r\n".encode()
+                    + b"Connection: close\r\n\r\n"
+                    + body
+                ),
+            )
+            head, _, tail = raw.partition(b"\r\n\r\n")
+            self.assertIn(b"HTTP/1.1 200", head)
+            self.assertIn(b"event: content_block_delta", tail)
+            self.assertIn(b"event: error", tail)
+            self.assertIn(b'"type":"api_error"', tail)
+            self.assertTrue(raw.rstrip().endswith(b"0"))
+        finally:
+            self.stop_gateway(proc)
+            upstream.close()
 
     def test_connect_blocks_claude_hosts_and_tunnels_other_hosts(self):
         proc, port = self.start_gateway()


### PR DESCRIPTION
## Summary
- align Rust gateway error envelopes with Python proxy error types for DeepSeek formal proxy paths
- add retry/first-frame stream handling with downstream keepalive and Python-shaped SSE errors
- expand Rust gateway loopback tests for upstream errors, malformed requests, keepalive, stream status errors, and midstream truncation

## Scope
- only affects opt-in Rust gateway behavior for deepseek + shim_mode=off
- does not expand Rust eligibility, default Python fallback, qwen/relay/OpenAI custom, scratch/model discovery, catalog schema, Tauri command schemas, or UI

## Local validation
- git diff --check
- PATH="/Users/superjj/.cargo/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/opt/homebrew/bin:/Users/superjj/.codex/tmp/arg0/codex-arg0qS9cw8:/Users/superjj/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/superjj/.local/bin:/Applications/Obsidian.app/Contents/MacOS:/Applications/Codex.app/Contents/Resources:/Applications/Obsidian.app/Contents/MacOS" cargo test (desktop/gateway)
- PATH="/Users/superjj/.cargo/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/opt/homebrew/bin:/Users/superjj/.codex/tmp/arg0/codex-arg0qS9cw8:/Users/superjj/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/superjj/.local/bin:/Applications/Obsidian.app/Contents/MacOS:/Applications/Codex.app/Contents/Resources:/Applications/Obsidian.app/Contents/MacOS" cargo build (desktop/gateway)
- python3 -m unittest test.test_gateway_rust -v
- python3 -m unittest test.test_proxy_golden test.test_proxy_stream test.test_proxy_connect -v
- PATH="/Users/superjj/.cargo/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/opt/homebrew/bin:/Users/superjj/.codex/tmp/arg0/codex-arg0qS9cw8:/Users/superjj/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/superjj/.local/bin:/Applications/Obsidian.app/Contents/MacOS:/Applications/Codex.app/Contents/Resources:/Applications/Obsidian.app/Contents/MacOS" cargo test --manifest-path desktop/src-tauri/Cargo.toml
- bash test/run-contract.sh
- bash test/run_all.sh

## Not validated
- CI green
- GUI E2E
- live provider behavior
- real ~/.claude-science
- real token/env keys
- port 8765 runtime behavior
- signing/notarization/Gatekeeper
- full packaged app runtime