### PR TITLE
docs: record v0.7.0 release evidence

### DIFF
--- a/.agents/context/current-release.md
+++ b/.agents/context/current-release.md
@@ -1,20 +1,20 @@
 # 当前发布快照
 
-最后复核：2026-07-16（Asia/Shanghai）
+最后复核：2026-07-17（Asia/Shanghai）
 
 | 项目 | 快照 |
 |---|---|
-| 当前公开正式版本 | `v0.6.0` |
-| v0.6.0 release source / peeled tag | `70950f1d1e8a18e8bd43db9b9a45e4e22ef2bcb4` |
-| v0.6.0 annotated tag object | `a8a2d8973315271220d539822d333c3fb5dad12f`；unsigned |
-| v0.6.0 GitHub Release | 已公开，非 draft、非 prerelease；发布时间 `2026-07-15T18:46:29Z` |
-| v0.6.0 发布附件 | `CSSwitch_0.6.0_aarch64.dmg`，9,701,904 bytes |
-| v0.6.0 附件 SHA-256 | `4a67973ef090e6d0a0dbc8e85d456c81d87733831555f6ea84cecb75e563dfb4` |
-| v0.6.0 发布证据 | [最终 source、artifact 与分发复核](../../docs/evidence/releases/v0.6.0.md) |
+| 当前公开正式版本 | `v0.7.0` |
+| v0.7.0 release source / peeled tag | `b8ed8d8a818c38e5b1823c11e357a7fdbda81b85` |
+| v0.7.0 annotated tag object | `2beead064b734d5a8e0af93ef951fa374adda050`；unsigned |
+| v0.7.0 GitHub Release | Latest，已公开，非 draft、非 prerelease；发布时间 `2026-07-17T08:56:38Z` |
+| v0.7.0 发布附件 | `CSSwitch_0.7.0_aarch64.dmg`，12,267,718 bytes |
+| v0.7.0 附件 SHA-256 | `72fc5dc47dd428951a055762296e1b654af3b577b62ff409b72910698c5c700f` |
+| v0.7.0 发布证据 | [Codex、最终 artifact 与分发复核](../../docs/evidence/releases/v0.7.0.md) |
 | v0.5.0 release source / peeled tag | `557a01f1f35c13b766645b72bb6858f20ddbea6e` |
 | v0.5.0 GitHub Release | 已公开，非 draft、非 prerelease；发布时间 `2026-07-14T04:30:49Z` |
 | v0.5.0 发布附件 | `CSSwitch_0.5.0_aarch64.dmg`，6,741,103 bytes |
 | v0.5.0 附件 SHA-256 | `08d5dabe8a867052b10b806239751528429ccbf1c6e8ea4e5047702bdf7c3baf` |
-| v0.6.0 clean release worktree | `/private/tmp/csswitch-release-v060-70950f1` |
+| v0.7.0 clean release worktree | `/private/tmp/csswitch-release-v070-b8ed8d8` |
 
-完整 artifact 与分发边界分别见 [v0.6.0 release evidence](../../docs/evidence/releases/v0.6.0.md) 和 [v0.5.0 release evidence](../../docs/evidence/releases/v0.5.0.md)。涉及发布状态时仍应重新查询远端；本快照不代替 live Git / GitHub 检查。
+完整 artifact 与分发边界分别见 [v0.7.0 release evidence](../../docs/evidence/releases/v0.7.0.md) 和 [v0.6.0 release evidence](../../docs/evidence/releases/v0.6.0.md)。涉及发布状态时仍应重新查询远端；本快照不代替 live Git / GitHub 检查。

--- a/.agents/context/known-issues.md
+++ b/.agents/context/known-issues.md
@@ -1,10 +1,17 @@
 # 当前已知问题与证据缺口
 
-最后整理：2026-07-16。已解决历史放入 CHANGELOG 或 dated evidence，不在这里堆叠。
+最后整理：2026-07-17。已解决历史放入 CHANGELOG 或 dated evidence，不在这里堆叠。
 
 ## 分发
 
-- v0.6.0 公开附件只有 ad-hoc 签名，没有 Developer ID 团队身份、notarization 或 stapled ticket；Gatekeeper 对包内 app 的评估为 `rejected`。首次打开可能需要用户右键选择“打开”。
+- v0.7.0 公开附件只有 ad-hoc seal，没有 Developer ID 团队身份、notarization 或 stapled ticket；Gatekeeper 对包内 app 的评估为 `rejected`。首次打开可能需要用户右键选择“打开”。
+
+## Codex
+
+- Codex 是默认关闭的实验能力。上游账号权限、动态模型目录和 Responses 协议可能变化；单账号、浏览器登录、macOS Apple Silicon 是当前边界。
+- 不支持设备码、多账号、代理认证、PAC、自定义 CA、系统代理自动发现或 TUN 检测；Finder 启动的环境变量与终端可能不同，`direct` 也可能仍由系统 TUN 接管。
+- Acceptance 候选已有真实 CSSwitch OAuth、模型和 Science 最小文本成功证据，但最终公开 v0.7.0 DMG 没有重新执行真实 OAuth / 模型 / 推理；两者不能合并为同一层证据。
+- v3 配置回滚到 v0.6.0 前必须先在 v0.7.0 导出并降级到 v2，或停止全部 CSSwitch 进程后恢复 v2 备份；删除 Codex profile 本身不会降低 schema。
 
 ## Science / Skill
 

--- a/.agents/context/verified-state.md
+++ b/.agents/context/verified-state.md
@@ -1,6 +1,18 @@
 # 已验证状态快照
 
-最后复核：2026-07-16。
+最后复核：2026-07-17。
+
+## v0.7.0 已发布
+
+- 新增默认关闭的 Codex → Claude Science 实验桥接：CSSwitch 自有浏览器 OAuth、动态多模型目录、Science alias、Responses/SSE 文本与工具链路，以及 direct / HTTP(S) / SOCKS5 / SOCKS5h 统一网络路线。
+- Codex 认证保存在 CSSwitch 自有 data root 私有文件中，不使用 macOS Keychain，也不读取、复用、修改或删除原生 `~/.codex` 登录；单账号、browser-only 和不支持代理认证 / PAC / 自定义 CA / TUN 检测是公开边界。
+- 功能树完整 Gate 退出 0并汇总 `release-ready green: YES`：Desktop 311 passed / 3 explicit ignored，Gateway 228 lib + 1 CLI passed；fmt、clippy `-D warnings`、前端与 `git diff --check` 通过。
+- 用户在 0.6.0 版本号的 Acceptance 候选上完成 CSSwitch OAuth、动态模型、`Codex / GPT-5.6-Sol` 和 Science 最小文本 live 验收，修复后日志无 `Claude is temporarily unavailable`；该候选不是最终 v0.7.0 DMG，不能冒充最终附件 live 证据。
+- PR #60 已合并；公开 peeled `v0.7.0`、发布时 `origin/main` 与 clean build source 都是 `b8ed8d8a818c38e5b1823c11e357a7fdbda81b85`。
+- 最终 DMG 为 12,267,718 bytes，SHA-256 `72fc5dc47dd428951a055762296e1b654af3b577b62ff409b72910698c5c700f`；GitHub asset metadata 相同，重新下载后逐字节一致，`hdiutil verify` 为 `VALID`。
+- 最终 DMG 只读挂载后 app 为 0.7.0 / arm64，Desktop、Gateway 与 bundle 逐字节相同；隔离 status 返回 sidecar v3 `state_missing`，隔离 app 启动未自动拉起 provider / Gateway。正式 `/Applications/CSSwitch.app` 未修改。
+- 新 1 号暖橙圆角图标已进入源码和 DMG；四角透明、无可见黑边，没有合并 UI 重制代码。
+- app seal 结构有效但身份为 ad-hoc、无 TeamIdentifier；Gatekeeper 拒绝且没有 stapled ticket。这是明确的无正式签名发布边界。
 
 ## v0.6.0 已发布
 

--- a/docs/evidence/releases/README.md
+++ b/docs/evidence/releases/README.md
@@ -1,5 +1,6 @@
 # 发布证据索引
 
+- [v0.7.0](v0.7.0.md)：Codex 实验桥接、最终 source / DMG、公开附件与 Acceptance live 证据边界。
 - [v0.6.0](v0.6.0.md)：最终 source、附件、Acceptance 安装与公开分发证据。
 - [v0.5.0](v0.5.0.md)：已发布附件与 2026-07-14 独立复核。
 - [v0.4.2](v0.4.2.md)：历史 pre-release 证据，不代表最终公开发布状态。

--- a/docs/evidence/releases/v0.7.0.md
+++ b/docs/evidence/releases/v0.7.0.md
@@ -1,0 +1,78 @@
+# CSSwitch v0.7.0 发布证据
+
+复核时间：2026-07-17（Asia/Shanghai）。本文件分别记录源码闸门、Codex Acceptance live 行为、最终 artifact 和公开分发；Acceptance 的 live 结果不能自动外推为最终 DMG 已执行真实 OAuth / 推理。
+
+## Source 与公开发布
+
+| 项目 | 结果 |
+|---|---|
+| release source / 发布时 `origin/main` | `b8ed8d8a818c38e5b1823c11e357a7fdbda81b85` |
+| annotated tag object | `2beead064b734d5a8e0af93ef951fa374adda050` |
+| peeled `v0.7.0^{}` | `b8ed8d8a818c38e5b1823c11e357a7fdbda81b85` |
+| tag 签名 | unsigned annotated tag |
+| 版本 / 架构 | `v0.7.0` / macOS Apple Silicon |
+| GitHub Release | `CSSwitch v0.7.0`，Latest、非 draft、非 prerelease |
+| 发布时间 | `2026-07-17T08:56:38Z` |
+| 页面 | `https://github.com/SuperJJ007/CSSwitch/releases/tag/v0.7.0` |
+
+Release 的 `targetCommitish` 为 `main`；公开 source identity 以上述 peeled tag 为准。PR #60 的功能提交为 `0db04c4060b891fc3bb1e097058fa69fa2bdbea3`，合并提交为 `b8ed8d8…`；两者 tree 都是 `55f724ca1a615b52599959ae8e9413bea68a9745`，`git diff --quiet` 退出 0。
+
+## 自动 Gate 与独立审查
+
+功能树在提交前运行：
+
+```text
+bash test/run_all.sh --require-release-ready
+```
+
+结果退出 0：offline、loopback、scripts、rust、frontend 五层全部通过并汇总为 `release-ready green: YES`。Desktop 为 311 passed / 3 explicit ignored，Gateway 为 228 lib + 1 CLI passed；ignored 项仍需显式隔离 runtime / 真机条件，不计作自动通过。Gateway 与 Desktop 的 `cargo fmt --check`、`cargo clippy -- -D warnings`，前端语法检查和 `git diff --check` 也通过。
+
+Codex 推理修复、说明与回滚、选定图标、最终 DMG 和公开 Release 分阶段交给 GPT-5.6-Sol xhigh 子 agent 独立复核；发布前几个阶段均为 P1 none / P2 none。公开 Release 的最终复核结果另以该次审查实际输出为准。
+
+## Acceptance live 行为及其边界
+
+用户在独立 `/Applications/CSSwitch Acceptance.app` 上完成 CSSwitch 自有浏览器 OAuth，看到动态模型目录，并在 Science 选择 `Codex / GPT-5.6-Sol`。直接 Gateway 最小请求返回 `pong`，Science UI 最小文本请求返回“端到端成功”；同一修复后 Science 日志区间没有 `Invalid content type` 或 `Claude is temporarily unavailable`。该候选已包含最终的 `codex_cli_rs` User-Agent、成功 SSE 缺少 `Content-Type` 时的有界前缀识别和“不重发推理 POST”修复。详细证据见 [2026-07-17 Codex browser-only Acceptance](../investigations/2026-07-17-codex-browser-only-acceptance.md)。
+
+该 Acceptance artifact 当时仍显示 0.6.0，且来自尚未提交的功能树；它不是本页最终 v0.7.0 DMG，二进制 hash 也不同。因此它证明候选功能链路在该用户环境中成功过，不证明从公开 DMG 安装后重新执行了真实 Codex OAuth、模型或 Science 推理。
+
+## 最终附件身份
+
+| 项目 | 值 |
+|---|---|
+| clean build source | `b8ed8d8a818c38e5b1823c11e357a7fdbda81b85` |
+| 本地最终 DMG | `CSSwitch_0.7.0_aarch64.dmg` |
+| 本地大小 | 12,267,718 bytes |
+| 本地 SHA-256 | `72fc5dc47dd428951a055762296e1b654af3b577b62ff409b72910698c5c700f` |
+| GitHub asset | 同名；`state=uploaded`；content type `application/octet-stream` |
+| GitHub size / digest | 12,267,718 bytes / `sha256:72fc5dc47dd428951a055762296e1b654af3b577b62ff409b72910698c5c700f` |
+| 重新下载复核 | 与本地最终 DMG `cmp` 逐字节一致；大小和 SHA-256 相同 |
+
+`hdiutil verify` 对最终 DMG 返回 `VALID`。只读挂载后的 app 为 0.7.0、`com.csswitch.menubar`，Desktop 和 Gateway 都是 arm64；挂载包内二进制与 clean build bundle 逐字节相同，包含预期 scripts 且不含旧 `Contents/Resources/proxy`。包内 Gateway 在隔离 HOME 下执行 status 返回 sidecar v3 的 `authenticated=false, reason=state_missing`；挂载 app 在隔离 HOME 启动成功，没有自动启动 provider / Gateway，随后只终止本轮测试进程。正式 `/Applications/CSSwitch.app` 与既有 Acceptance runtime 均未修改。
+
+构建后先对 Gateway、再对外层 app 执行本地 ad-hoc seal，并重建 DMG；构建过程中产生、缺少完整外层 resource seal 的 pre-seal DMG 被保留在仓库外且没有上传。
+
+## 图标
+
+最终包使用用户选定的 1 号暖橙圆角开关图标，没有合并 UI 重制代码。源码 `icon.png` 为 512×512 RGBA，四角像素都是完全透明，未发现 alpha ≥128 的黑色像素；包内 `icon.icns` 与源码逐字节一致。关键 hash：
+
+- `icon.png`: `faab74cae41fb9115e9205369a4e4d6318727064eece7672bda82ef810bdf718`
+- `icon.icns`: `823e311418fd009bcad63211a58ad0f3b91a58dc4dcad9e0645195bc2c51a858`
+
+## 签名、notarization 与 Gatekeeper
+
+| 检查 | 结果 | 准确含义 |
+|---|---|---|
+| `codesign --verify --deep --strict --verbose=4 CSSwitch.app` | 通过 | app seal 与内嵌代码结构有效 |
+| `codesign -dvvv CSSwitch.app` | `Signature=adhoc`, `TeamIdentifier=not set` | 不是 Developer ID 团队签名 |
+| `hdiutil verify CSSwitch_0.7.0_aarch64.dmg` | `VALID` | 磁盘镜像结构与内部校验有效 |
+| `spctl --assess --type execute ... CSSwitch.app` | exit 3，`rejected` | Gatekeeper 不接受该 ad-hoc app |
+| `xcrun stapler validate ...dmg` | exit 65，无 ticket | 没有 stapled notarization ticket |
+
+本版本按开源无正式签名边界发布，不要求 Apple 开发者账户。首次打开可能需要在 Finder 中右键选择“打开”；ad-hoc seal 通过不能表述为 Developer ID、公证或 Gatekeeper 通过。
+
+## 尚未建立或不在本次声明中的层
+
+- 从公开 v0.7.0 DMG 安装后重新执行的真实 Codex OAuth、刷新、动态模型和 Science live 推理；
+- Developer ID 签名、Apple notarization、stapled ticket 和 Gatekeeper acceptance；
+- macOS Intel、Windows、Linux、多账号、设备码、代理认证、PAC、自定义 CA、系统代理自动发现和 TUN 检测；
+- 所有上游账号权限、模型目录、协议变化以及所有 provider / Skill / SSH 环境的穷举验证。


### PR DESCRIPTION
## Summary
- record v0.7.0 source, tag, artifact, icon and public Release identity
- separate Acceptance live Codex evidence from final DMG artifact/runtime evidence
- refresh current release, verified state and known issue snapshots

## Verification
- GitHub latest/tag/asset metadata checked live
- downloaded public DMG is byte-identical to the local final artifact
- git diff --check
- GPT-5.6-Sol xhigh independent docs review: P1 none, P2 none